### PR TITLE
Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ for example:
 $ python3 cleanup-discogs.py -c cleanup.config -d ~/discogs-data/discogs_20170801_releases.xml.gz
 ```
 
+To check a single release use `-r`:
+
+```console
+$ python3 cleanup-discogs.py -c /path/to/config -d /path/to/discogs/dump -r release_number
+```
+
+for example:
+
+```console
+$ python3 cleanup-discogs.py -c cleanup.config -d ~/discogs-data/discogs_20170801_releases.xml.gz -r 1234
+```
+
+In case the number cannot be found the program will exit with an error code
+and an error message. Please note that because the Discogs release files are
+very big and the file has to be searched from the beginning it can take quite
+some time if the release number is a high number.
+
 # List of checks
 
 Below is a list of checks implemented in `cleanup-discogs.py`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ More background information about these scripts available on my blog:
 
 <https://vinylanddata.blogspot.com/>
 
-## cleanup-for-discogs.py
+Why this happens is well explained here:
+
+<https://www.well.com/~doctorow/metacrap.htm>
+
+## cleanup-discogs.py
 
 Python script to find known "smells" in Discogs database dump files. Prints out
 URLs of releases to be fixed.
@@ -63,3 +67,62 @@ for example:
 ```console
 $ python3 cleanup-discogs.py -c cleanup.config -d ~/discogs-data/discogs_20170801_releases.xml.gz
 ```
+
+# List of checks
+
+Below is a list of checks implemented in `cleanup-discogs.py`.
+
+## Depósito Legal
+
+Until August 2017 the "depósito legal" data (mostly used on Spanish releases,
+but also on some releases from South America) was essentially free text in the
+"Barcode and Other Identifiers" (BaOI) section.
+
+Since July 2017 XML there is a separate field for it and it has become a first
+class citizen in BaOI), but there are still many releases where this field has
+not yet been used and where the information is in another field instead, such
+as "Matrix/Runout", "Label Code" or "Other", with a hint in the "description"
+subfield. There are many spellings and misspellings in the "description"
+subfield, so the depósito legal isn't always easy to find.
+
+## Label Code
+
+In early Discogs day "Other" was used to specify the label code, but at some
+point a dedicated field called "Label Code" was introduced. There are still
+many entries that haven't been changed. There are also many users that do not
+know what the field "Label Code" means and will put any data found on a label
+of a release in this field (instead of the actual label code as specified in
+the Discogs guidelines).
+
+## SPARS Code
+
+Like with other fields in the past "Other" was used to specify the SPARS code,
+but at some point a dedicated field called "SPARS Code" was introduced. There
+are still many entries that haven't been changed though. There are also users
+who put the SPARS Code in other places, such as the free text subfield of
+"Format", mostly for classical CDs.
+
+## Rights Society
+
+Before a proper "Rights Society" field was created the "Other" field was used to
+record the rights society. There are also errors where the Rights Society is
+put into other fields such as "ISRC" (due to them being next to each other in
+the drop down box to pick the field name when entering data). There are also
+many misspellings of the names of rights societies and all kinds of encoding
+issues.
+
+## Month checks
+
+In the past it was mandatory to record the month as 00 if it wasn't known
+but this is no longer allowed. When saving an entry that has 00 as the
+number of the month Discogs will throw an error.
+
+## Regular HTML hyperlinks URLs instead of using markup
+
+In the past it was OK to have normal HTML hyperlinks (in fact it was the only
+way to record links), but using regular HTML hyperlinks has been discouraged
+and have been replaced by markup:
+
+<https://support.discogs.com/en/support/solutions/articles/13000014661-how-can-i-format-text->
+
+There are still many releases where old hyperlinks are used.

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -61,6 +61,26 @@ import click
 import discogssmells
 
 RIGHTS_SOCIETY_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None})
+
+# some values that are not the actual data, but are metadata describing
+# something about the SID codes (readable, missing, and so on) or about
+# actions that need to be taken.
+SID_IGNORE = set(['none', '(none)', '[none]', '<none>', 'non', 'nond', 'none or hidden',
+                  'not present', '(not present)', '[not present]',
+                  'missing', '(missing)', '[missing]', '(missing info)', '[missing data]',
+                  '[not available]', 'unknown', '(unknown)', '[unknown]', 'unk',
+                  'not visible', 'none visible', 'non visible', 'none seen', 'none entered',
+                  'not entered', '[not entered]', '(not entered)', '(not entered))',
+                  '[nothing entered]', '[to be entered]', 'to be confirmed', '[?]', '[? ?]',
+                  '?', '???????', 'no', 'not recorded', '[not recorded]', 'not supplied',
+                  '[not supplied]', 'unreadable', '[unreadable]', '(unreadable)', '[not given]',
+                  'not added', 'none cited', 'not provided', 'not stated', '[not stated]',
+                  'not submitted', '[not submitted]', '(not apparent)', '[not apparent]',
+                  'none apparent', 'illegible', 'no sid', 'no sid code', 'no sid codes',
+                  'not detectable', '[not discernable]', 'not readable', 'not clearly readable',
+                  '[not reported]', 'no code', '[no code]', '[empty]', 'cannot locate',
+                  'to be completed', 'obscured', 'invisible'])
+
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
                            'VHS', 'DCC', 'Memory Stick', 'Edison Disc'])
 
@@ -70,8 +90,9 @@ SPARS_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None, '·': None,
 
 # Translation table for mastering SID codes
 # some people insist on using ƒ instead of f
+# or ρ instead of p
 MASTERING_SID_TRANSLATE = str.maketrans({' ': None, '-': None,
-                                        'ƒ': 'f'})
+                                        'ƒ': 'f', 'ρ': 'p'})
 
 # grab the current year. Make sure to set the clock of your machine
 # to the correct date or use NTP!
@@ -1373,7 +1394,7 @@ def main(cfg, datadump):
                                     if identifier_type == 'Mastering SID Code':
                                         value = identifier.get('value').strip()
                                         value_lower = identifier.get('value').lower().strip()
-                                        if value_lower != 'none':
+                                        if value_lower not in SID_IGNORE:
                                             # cleanup first for not so heavy formatting booboos
                                             master_tmp = value_lower.translate(MASTERING_SID_TRANSLATE)
                                             res = discogssmells.masteringsidre.match(master_tmp)

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -306,175 +306,173 @@ def main(cfg, datadump, requested_release):
     # Most of the defaults (but not all!) are set to 'True'
     config_settings = CleanupConfig()
 
-    for section in config.sections():
-        if section == 'cleanup':
-            # store settings for depósito legal checks
-            try:
-                config_settings.deposito_legal = config.getboolean(section, 'deposito')
-            except:
-                pass
+    # store settings for depósito legal checks
+    try:
+        config_settings.deposito_legal = config.getboolean('cleanup', 'deposito')
+    except:
+        pass
 
-            # store settings for rights society checks
-            try:
-                config_settings.rights_society = config.getboolean(section, 'rights_society')
-            except:
-                pass
+    # store settings for rights society checks
+    try:
+        config_settings.rights_society = config.getboolean('cleanup', 'rights_society')
+    except:
+        pass
 
-            # store settings for label code checks
-            try:
-                config_settings.label_code = config.getboolean(section, 'label_code')
-            except:
-                pass
+    # store settings for label code checks
+    try:
+        config_settings.label_code = config.getboolean('cleanup', 'label_code')
+    except:
+        pass
 
-            # store settings for label name checks
-            try:
-                config_settings.label_name = config.getboolean(section, 'label_name')
-            except:
-                pass
+    # store settings for label name checks
+    try:
+        config_settings.label_name = config.getboolean('cleanup', 'label_name')
+    except:
+        pass
 
-            # store settings for ISRC checks
-            try:
-                config_settings.isrc = config.getboolean(section, 'isrc')
-            except:
-                pass
+    # store settings for ISRC checks
+    try:
+        config_settings.isrc = config.getboolean('cleanup', 'isrc')
+    except:
+        pass
 
-            # store settings for ASIN checks
-            try:
-                config_settings.asin = config.getboolean(section, 'asin')
-            except:
-                pass
+    # store settings for ASIN checks
+    try:
+        config_settings.asin = config.getboolean('cleanup', 'asin')
+    except:
+        pass
 
-            # store settings for mastering SID checks
-            try:
-                config_settings.mastering_sid = config.getboolean(section, 'mastering_sid')
-            except:
-                pass
+    # store settings for mastering SID checks
+    try:
+        config_settings.mastering_sid = config.getboolean('cleanup', 'mastering_sid')
+    except:
+        pass
 
-            # store settings for mould SID checks
-            try:
-                config_settings.mould_sid = config.getboolean(section, 'mould_sid')
-            except:
-                pass
+    # store settings for mould SID checks
+    try:
+        config_settings.mould_sid = config.getboolean('cleanup', 'mould_sid')
+    except:
+        pass
 
-            # store settings for mould SID strict checks
-            try:
-                config_settings.mould_sid_strict = config.getboolean(section, 'mould_sid_strict')
-            except:
-                pass
+    # store settings for mould SID strict checks
+    try:
+        config_settings.mould_sid_strict = config.getboolean('cleanup', 'mould_sid_strict')
+    except:
+        pass
 
-            # store settings for SPARS Code checks
-            try:
-                config_settings.spars = config.getboolean(section, 'spars')
-            except:
-                pass
+    # store settings for SPARS Code checks
+    try:
+        config_settings.spars = config.getboolean('cleanup', 'spars')
+    except:
+        pass
 
-            # store settings for Indian PKD checks
-            try:
-                config_settings.indian_pkd = config.getboolean(section, 'pkd')
-            except:
-                pass
+    # store settings for Indian PKD checks
+    try:
+        config_settings.indian_pkd = config.getboolean('cleanup', 'pkd')
+    except:
+        pass
 
-            # store settings for Greek license number checks
-            try:
-                config_settings.greek_license = config.getboolean(section, 'greek_license_number')
-            except:
-                pass
+    # store settings for Greek license number checks
+    try:
+        config_settings.greek_license = config.getboolean('cleanup', 'greek_license_number')
+    except:
+        pass
 
-            # store settings for CD+G checks
-            try:
-                config_settings.cd_plus_g = config.getboolean(section, 'cdg')
-            except:
-                pass
+    # store settings for CD+G checks
+    try:
+        config_settings.cd_plus_g = config.getboolean('cleanup', 'cdg')
+    except:
+        pass
 
-            # store settings for Matrix checks
-            try:
-                config_settings.matrix = config.getboolean(section, 'matrix')
-            except:
-                pass
+    # store settings for Matrix checks
+    try:
+        config_settings.matrix = config.getboolean('cleanup', 'matrix')
+    except:
+        pass
 
-            # store settings for label checks
-            try:
-                config_settings.labels = config.getboolean(section, 'labels')
-            except:
-                pass
+    # store settings for label checks
+    try:
+        config_settings.labels = config.getboolean('cleanup', 'labels')
+    except:
+        pass
 
-            # store settings for manufacturing plant checks
-            try:
-                config_settings.pressing_plants = config.getboolean(section, 'plants')
-            except:
-                pass
+    # store settings for manufacturing plant checks
+    try:
+        config_settings.pressing_plants = config.getboolean('cleanup', 'plants')
+    except:
+        pass
 
-            # check for Czechoslovak manufacturing dates
-            try:
-                config_settings.czechoslovak_dates = config.getboolean(section, 'manufacturing_date_cs')
-            except:
-                pass
+    # check for Czechoslovak manufacturing dates
+    try:
+        config_settings.czechoslovak_dates = config.getboolean('cleanup', 'manufacturing_date_cs')
+    except:
+        pass
 
-            # check for Czechoslovak and Czech spelling (0x115 used instead of 0x11B)
-            try:
-                config_settings.czechoslovak_spelling = config.getboolean(section, 'spelling_cs')
-            except:
-                pass
+    # check for Czechoslovak and Czech spelling (0x115 used instead of 0x11B)
+    try:
+        config_settings.czechoslovak_spelling = config.getboolean('cleanup', 'spelling_cs')
+    except:
+        pass
 
-            # store settings for tracklisting checks, default True
-            try:
-                config_settings.tracklisting = config.getboolean(section, 'tracklisting')
-            except:
-                pass
+    # store settings for tracklisting checks, default True
+    try:
+        config_settings.tracklisting = config.getboolean('cleanup', 'tracklisting')
+    except:
+        pass
 
-            # store settings for artists, default True
-            try:
-                config_settings.artist = config.getboolean(section, 'artist')
-            except:
-                pass
+    # store settings for artists, default True
+    try:
+        config_settings.artist = config.getboolean('cleanup', 'artist')
+    except:
+        pass
 
-            # store settings for credits list checks
-            config_settings.credits = False
-            try:
-                if config.get(section, 'credits') == 'yes':
-                    creditsfile = config.get(section, 'creditsfile')
-                    if os.path.exists(creditsfile):
-                        # TODO: fix
-                        config_settings.creditsfile = creditsfile
-                        config_settings.credits = True
-            except:
-                pass
+    # store settings for credits list checks
+    config_settings.credits = False
+    try:
+        if config.get('cleanup', 'credits') == 'yes':
+            creditsfile = config.get('cleanup', 'creditsfile')
+            if os.path.exists(creditsfile):
+                # TODO: fix
+                config_settings.creditsfile = creditsfile
+                config_settings.credits = True
+    except:
+        pass
 
-            # store settings for URLs in Notes checks
-            try:
-                config_settings.url_in_html = config.getboolean(section, 'html')
-            except:
-                pass
+    # store settings for URLs in Notes checks
+    try:
+        config_settings.url_in_html = config.getboolean('cleanup', 'html')
+    except:
+        pass
 
-            # month is 00 check: default is False
-            try:
-                config_settings.month_valid = config.getboolean(section, 'month')
-            except:
-                pass
+    # month is 00 check: default is False
+    try:
+        config_settings.month_valid = config.getboolean('cleanup', 'month')
+    except:
+        pass
 
-            # year is wrong check: default is False
-            try:
-                config_settings.year_valid = config.getboolean(section, 'year')
-            except:
-                pass
+    # year is wrong check: default is False
+    try:
+        config_settings.year_valid = config.getboolean('cleanup', 'year')
+    except:
+        pass
 
-            # reporting all: default is False
-            try:
-                config_settings.report_all = config.getboolean(section, 'reportall')
-            except:
-                pass
+    # reporting all: default is False
+    try:
+        config_settings.report_all = config.getboolean('cleanup', 'reportall')
+    except:
+        pass
 
-            # debug: default is False
-            try:
-                config_settings.debug = config.getboolean(section, 'debug')
-            except:
-                pass
+    # debug: default is False
+    try:
+        config_settings.debug = config.getboolean('cleanup', 'debug')
+    except:
+        pass
 
-            # report creative commons references: default is False
-            try:
-                config_settings.creative_commons = config.getboolean(section, 'creative_commons')
-            except:
-                pass
+    # report creative commons references: default is False
+    try:
+        config_settings.creative_commons = config.getboolean('cleanup', 'creative_commons')
+    except:
+        pass
 
     try:
         with gzip.open(datadump, "rb") as dumpfile:
@@ -494,7 +492,7 @@ def main(cfg, datadump, requested_release):
                             element.clear()
                             continue
                         elif requested_release < release_id:
-                            print(f'Release {requested_release} cannot be found in data set!, exiting',
+                            print(f'Release {requested_release} cannot be found in data set!',
                                   file=sys.stderr)
                             sys.exit(1)
 
@@ -1273,7 +1271,7 @@ def main(cfg, datadump, requested_release):
                                                             if recorded_format in formats:
                                                                 try:
                                                                     int(track_elem.text)
-                                                                    print_error(counter, f'Tracklisting ({recorded_format})', release_id)
+                                                                    print_error(counter, f'Tracklisting uses numbers ({recorded_format})', release_id)
                                                                     counter += 1
                                                                     tracklist_correct = False
                                                                     break

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -243,7 +243,7 @@ class DiscogsHandler():
                             print('%8d -- Pressing plant Sony DADC (wrong year %s): https://www.discogs.com/release/%s' % (self.count, self.year, str(self.release)))
                     '''
 
-                    for pl in discogssmells.plants:
+                    for pl in discogssmells.plants_compact_disc:
                         if self.contentbuffer == pl[0]:
                             if 'CD' in self.formattexts:
                                 if self.year < pl[1]:

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -169,7 +169,6 @@ class DiscogsHandler():
                 #        print(self.genres)
                 #        sys.exit(0)
                 self.artists.add(self.contentbuffer)
-        if self.intracklist and self.inposition:
             '''
             # https://en.wikipedia.org/wiki/Phonograph_record#Microgroove_and_vinyl_era
             if 'Vinyl' in self.formattexts:
@@ -191,10 +190,6 @@ class DiscogsHandler():
                 self.noartist = False
         elif name == 'role':
             self.inrole = True
-        elif name == 'tracklist':
-            self.intracklist = True
-        elif name == 'position':
-            self.inposition = True
         elif name == 'identifier':
             attritems = dict(attrs.items())
             if 'value' in attritems:
@@ -231,11 +226,6 @@ class DiscogsHandler():
                                     self.count += 1
                                     print('%8d -- Rights Society (wrong character set, %s): https://www.discogs.com/release/%s' % (self.count, attrvalue, str(self.release)))
                             return
-                if self.config['check_label_code'] and not self.inlabelcode:
-                    if self.description in discogssmells.label_code_ftf:
-                        self.count += 1
-                        print('%8d -- Label Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                        return
                 if self.country == 'Czechoslovakia':
                     if self.config['check_manufacturing_date_cs']:
                         # config hack, needs to be in its own configuration option
@@ -916,6 +906,7 @@ def main(cfg, datadump, requested_release):
                                 # Label Code
                                 if config_settings.label_code:
                                     value = identifier.get('value').lower()
+                                    description = identifier.get('description', '').lower()
                                     if identifier_type == 'Label Code':
                                         # check how many people use 'O' instead of '0'
                                         if value.startswith('lc'):
@@ -930,6 +921,10 @@ def main(cfg, datadump, requested_release):
                                             if discogssmells.labelcodere.match(value) is not None:
                                                 print_error(counter, f"Label Code (in {identifier_type})", release_id)
                                                 counter += 1
+
+                                        if description in discogssmells.label_code_ftf:
+                                            print_error(counter, f"Label Code (in {identifier_type})", release_id)
+                                            counter += 1
 
                                 # Matrix / Runout
                                 if config_settings.matrix:

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -427,8 +427,6 @@ class DiscogsHandler():
                 if v == 'Depósito Legal':
                     self.indeposito = True
                     self.depositofound = True
-                elif v == 'Barcode':
-                    self.inbarcode = True
                 elif v == 'Other':
                     self.inother = True
             if 'value' in attritems:
@@ -1375,7 +1373,7 @@ def main(cfg, datadump, release_nr):
 
                             # see https://support.discogs.com/en/support/solutions/articles/13000014661-how-can-i-format-text-
                             if config_settings.url_in_html:
-                                if '&lt;a href="http://www.discogs.com/release/' not in child.text:
+                                if '&lt;a href="http://www.discogs.com/release/' in child.text:
                                     print_error(counter, "old link (Notes)", release_id)
                                     counter += 1
                             if config_settings.creative_commons:

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -29,6 +29,11 @@ import discogssmells
 ISRC_TRANSLATE = str.maketrans({'-': None, ' ': None, '.': None,
                                 ':': None, '–': None,})
 
+# a list of possible label code false positives. These are
+# used when checking the catalog numbers.
+LABEL_CODE_FALSE_POSITIVES = set([654, 1005, 1060, 11358, 20234, 22804, 29480, 38653,
+                                  39161, 54361, 97031, 113617, 163947])
+
 RIGHTS_SOCIETY_DELIMITERS = ['/', '|', '\\', '-', '—', '•', '·', ',', ':', ' ', '&', '+']
 
 # a quick and dirty translation table to see if rights society values
@@ -743,7 +748,8 @@ def main(cfg, datadump, requested_release):
                                                             deposito_found = True
                                                             break
                                                     if not deposito_found and config_settings.debug:
-                                                        print(description, release_id)
+                                                        # print descriptions for debugging. Careful.
+                                                        print(f'Depósito Legal debug: {release_id}, {description}')
 
                                                 # sometimes the depósito value itself can be
                                                 # found in the free text field
@@ -1183,8 +1189,8 @@ def main(cfg, datadump, requested_release):
                                         counter += 1
                                 if config_settings.label_code:
                                     # check the catalog numbers for possible false positives,
-                                    # but exclude "Loft Classics".
-                                    if catno.startswith('lc') and label_id != 22804:
+                                    # but exclude "Loft Classics" and others
+                                    if catno.startswith('lc') and label_id not in LABEL_CODE_FALSE_POSITIVES:
                                         if discogssmells.labelcodere.match(catno) is not None:
                                             print_error(counter, f'Possible Label Code (in Catalogue Number: {catno})', release_id)
                                             counter += 1

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -867,18 +867,19 @@ def main(cfg, datadump, requested_release):
                                                 isrc_descriptions_seen.add(description_lower)
                                     else:
                                         # specifically check the description
-                                        if description_lower.startswith('isrc'):
-                                            print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
-                                            counter += 1
-                                        elif description_lower.startswith('issrc'):
-                                            print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
-                                            counter += 1
-                                        else:
-                                            for isrc in discogssmells.isrc_ftf:
-                                                if isrc in description_lower:
-                                                    print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
-                                                    counter += 1
-                                                    break
+                                        if description_lower != '':
+                                            if description_lower.startswith('isrc'):
+                                                print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
+                                                counter += 1
+                                            elif description_lower.startswith('issrc'):
+                                                print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
+                                                counter += 1
+                                            else:
+                                                for isrc in discogssmells.isrc_ftf:
+                                                    if isrc in description_lower:
+                                                        print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
+                                                        counter += 1
+                                                        break
                                 # Label Code
                                 if config_settings.label_code:
                                     value = identifier.get('value').lower()
@@ -1091,18 +1092,19 @@ def main(cfg, datadump, requested_release):
                                             # check the description of a field
                                             description = identifier.get('description', '').strip().lower()
 
-                                            # squash repeated spaces
-                                            description = re.sub(r'\s+', ' ', description)
-                                            if description in discogssmells.rights_societies_ftf:
-                                                errors = check_rights_society(value_upper)
+                                            if description != '':
+                                                # squash repeated spaces
+                                                description = re.sub(r'\s+', ' ', description)
+                                                if description in discogssmells.rights_societies_ftf:
+                                                    errors = check_rights_society(value_upper)
 
-                                                if errors:
-                                                    for error in errors:
-                                                        print_error(counter, f"Rights Society (in {identifier_type}, {error})", release_id)
+                                                    if errors:
+                                                        for error in errors:
+                                                            print_error(counter, f"Rights Society (in {identifier_type}, {error})", release_id)
+                                                            counter += 1
+                                                    else:
+                                                        print_error(counter, f'Rights Society (in {identifier_type} (description))', release_id)
                                                         counter += 1
-                                                else:
-                                                    print_error(counter, f'Rights Society (in {identifier_type} (description))', release_id)
-                                                    counter += 1
 
                                 # SPARS Code
                                 if config_settings.spars:
@@ -1155,11 +1157,12 @@ def main(cfg, datadump, requested_release):
                                             counter += 1
                                         else:
                                             description = identifier.get('description', '').lower()
-                                            for spars in discogssmells.spars_ftf:
-                                                if spars in description:
-                                                    print_error(counter, f'Possible SPARS Code (in {identifier_type})', release_id)
-                                                    counter += 1
-                                                    break
+                                            if description != '':
+                                                for spars in discogssmells.spars_ftf:
+                                                    if spars in description:
+                                                        print_error(counter, f'Possible SPARS Code (in {identifier_type})', release_id)
+                                                        counter += 1
+                                                        break
 
                                 # debug code to print all descriptions
                                 # Useful to find misspellings of various fields

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -65,8 +65,7 @@ pkd_re = re.compile(r"\d{1,2}/((?:19|20)?\d{2})")
 @dataclass
 class CleanupConfig:
     '''Default cleanup configuration'''
-    #artist: bool = False
-    artist: bool = True
+    artist: bool = False
     asin: bool = True
     cd_plus_g: bool = True
     creative_commons: bool = False

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -554,11 +554,16 @@ def main(cfg, datadump, requested_release):
                         if child.tag == 'artists' or child.tag == 'extraartists':
                             if config_settings.artist:
                                 for artist_elem in child:
+                                    artist_id = 0
+                                    artist_name = ''
                                     for artist in artist_elem:
                                         if artist.tag == 'id':
-                                            if artist.text == '0':
-                                                print_error(counter, 'Artist not in database', release_id)
-                                                counter += 1
+                                            artist_id = int(artist.text)
+                                        elif artist.tag == 'name':
+                                            artist_name = artist.text
+                                    if artist_id == 0:
+                                        print_error(counter, f'Artist \'{artist_name}\' not in database', release_id)
+                                        counter += 1
                         elif child.tag == 'companies':
                             if year is not None:
                                 for companies in child:

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -3,39 +3,6 @@
 # Tool to discover 'smells' in the Discogs data dump. It prints a list of URLs
 # of releases that need to be fixed.
 #
-# Why this happens:
-#
-# https://www.well.com/~doctorow/metacrap.htm
-#
-# Currently the following smells can be discovered:
-#
-# * depósito legal :: until recently the "depósito legal" data (for Spanish
-#   releases) was essentially free text in the "Barcode and Other Identifiers"
-#   section.
-#   Since the August 2017 dump there is a separate field for it (and it has
-#   effectively become a first class citizen in BaOI), but there are still many
-#   releases where this information has not been changed and is in an "Other"
-#   field in BaOI.
-#   Also, there are many misspellings, making it more difficult to find.
-# * label code :: until recently "Other" was used to specify the
-#   label code, but since then there is a dedicated field called
-#   "Label Code". There are still many entries that haven't been changed
-#   though.
-# * SPARS code :: in the past "Other" was used to specify the SPARS code, but
-#   at some point a dedicated field called "SPARS Code" was introduced.
-#   There are still many entries that haven't been changed though.
-# * rights society :: until a few years ago "Other" was used to specify
-#   the rights society, but since then there is a dedicated field called
-#   "Rights Society". There are still many entries that haven't been changed
-#   though.
-# * month as 00 :: in older releases it was allowed to have the month as 00
-#   but this is no longer allowed. When editing an entry that has 00 as the
-#   month Discogs will throw an error.
-# * hyperlinks :: in older releases it was OK to have normal HTML hyperlinks
-#   but these have been replaced by markup:
-#   https://support.discogs.com/en/support/solutions/articles/13000014661-how-can-i-format-text-
-#   There are still many releases where old hyperlinks are used.
-#
 # The results that are printed by this script are
 # by no means complete or accurate
 #
@@ -115,6 +82,9 @@ SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<n
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
                            'VHS', 'DCC', 'Memory Stick', 'Edison Disc'])
 
+# SID descriptions (either Mastering or Mould)
+SID_DESCRIPTIONS = ['source identification code', 'sid', 'sid code', 'sid-code']
+
 SPARS_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None, '·': None,
                                  '∙': None, '᛫': None, '[': None, ']': None,
                                  '-': None, '|': None, '/': None, '\\': None})
@@ -169,7 +139,6 @@ class DiscogsHandler():
         self.inbarcode = False
         self.inasin = False
         self.inisrc = False
-        self.inmouldsid = False
         self.inmatrix = False
         self.intracklist = False
         self.invideos = False
@@ -443,7 +412,6 @@ class DiscogsHandler():
         self.inbarcode = False
         self.inasin = False
         self.inisrc = False
-        self.inmouldsid = False
         self.inmatrix = False
         self.indeposito = False
         self.indescription = False
@@ -1033,6 +1001,9 @@ def check_spars(value, year):
                 errors.append(f"impossible year: {year}")
     return errors
 
+def check_rights_society(value):
+    pass
+
 @click.command(short_help='process BANG result files and output ELF graphs')
 @click.option('--config-file', '-c', 'cfg', required=True, help='configuration file', type=click.File('r'))
 @click.option('--datadump', '-d', 'datadump', required=True, help='discogs data dump file', type=click.Path(exists=True))
@@ -1456,7 +1427,7 @@ def main(cfg, datadump):
                                                 counter += 1
                                                 reported = True
 
-                                            # TODO: fix this
+                                            # TODO: fix this, possibly multiple rights societies
                                             if not reported and False:
                                                 print_error(counter, f"Rights Society (bogus value: {value})", release_id)
                                                 counter += 1

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -65,39 +65,52 @@ RIGHTS_SOCIETY_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None})
 # some values that are not the actual data, but are metadata describing
 # something about the SID codes (readable, missing, and so on) or about
 # actions that need to be taken.
-SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<none>', 'non',
-                  'nond', 'none found', 'none or hidden', 'not', 'not present', '(not present)',
-                  '[not present]', '<not present>', 'not present or not entered',
-                  '[not yet identified]', 'nothing', 'none / [missing]', 'missing', '(missing)',
-                  '[missing]', '(missing info)', '[missing data]', 'not available',
-                  '(not available)', '[not available]', 'not found', '(not found)', '[not found]',
-                  '(not found on cd)', 'missing / not found', '[indecipherable]',
-                  'not known', 'unknown', '(unknown)', '[unknown]', 'unk', 'not on disc',
-                  'not visible', '(not visible)', '[not visible]', 'none or not visible',
+SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<none>', '\'none\'',
+                  'none.', 'non', 'nond', 'none found', 'none or hidden', 'none given', 'not',
+                  'not present', '(not present)', '[not present]', '<not present>',
+                  'not present or not entered', '[not yet identified]', 'nothing',
+                  'none / [missing]', 'missing', '(missing)', '?missing?', '"missing"',
+                  '[missing]', '(missing info)', '[missing data]', '[missing or not entered]',
+                  'missing entry', 'not available', '(not available)', '[not available]', 'not found',
+                  '(not found)', '[not found]', '(not found on cd)', 'missing / not found',
+                  '[indecipherable]', '(indistinguishable)', 'not known', 'unknown', '(unknown)',
+                  '[unknown]', 'unk', 'not on disc', 'not visible', '(not visible)', '(not visble)',
+                  '[not visible]', 'not visible/present', 'none or not visible',
                   'not visible on both cds', 'not visible (black cd)', 'not visable',
-                  'none visible', '[none visible]', 'non visible', 'none seen', '[none seen]',
-                  '[not seen]', 'not registered', 'none entered', 'not entered', '[not entered]',
-                  '(not entered', '(not entered)', '[nothing entered]', 'none or not entered',
-                  '(none or not entered)', 'not entered / none', '[not entered/none]',
-                  '... not entered ...', '[to be entered]', 'not entered or not present',
-                  'need to be entered', 'to be confirmed', '[?]', '[? ?]', '?', '??', '????', '???????',
-                  '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied'),
-                  '[not supplied]', 'unreadable', '[unreadable]', '(unreadable)',
-                  'unreadable/too small', 'not given',
+                  'none visible', '[none visible]', 'non visible', '[no code visible]',
+                  '[none recorded]', '[none or missing]', 'none seen', '[none seen]', '[not seen]',
+                  'not registered', 'none detected', 'none entered', 'not entered',
+                  '[not entered]', '(not entered', '(not entered)', '[nothing entered]', 'not enterd',
+                  'none or not entered', '(none or not entered)', '[none or not entered]',
+                  'not entered / none', 'not entered or none', '(not entered or none)',
+                  '[not entered/none]', '... not entered ...', '[to be entered]',
+                  'not entered or not present', 'need to be entered',
+                  'to be confirmed', '[?]', '[? ?]', '?', '??', '???', '????', '???????',
+                  '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied)',
+                  '[not supplied]', 'none supplied', 'unreadable', '[unreadable]', '(unreadable)',
+                  'unreadable/too small', 'none or unreadable', 'nil', 'not given',
                   '(not given)', '[not given]', 'not inserted', '(not inserted)', '[not inserted]',
-                  'not added', '(not added)', '[not added]', '(to be added by another user)',
-                  'none cited', 'not provided', '(not provided)', 'not stated', '[not stated]',
-                  'not submitted', '[not submitted]', '(not apparent)', '[not apparent]',
-                  'none apparent', 'not legible', '[not legible]', 'illegible', '[illegible]',
-                  'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
+                  'not added', '(not added)', '[not added]', '[not added yet]',
+                  '(to be added by another user)', 'none cited', 'not provided', '(not provided)',
+                  'not stated', '[not stated]', 'not submitted', '[not submitted]',
+                  '[not submittted]', '(not apparent)', '[not apparent]', '<not apparent>',
+                  'none apparent', 'apparently none', 'not legible', '[not legible]', 'illegible',
+                  '[illegible]', 'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
                   'not detectable', 'none or not detectable', '[not discernable]', 'not readable',
                   '(not readable)', '[not readable]', '[none/not readable]', '[none / not readable]',
                   'not readable (to small)', 'not clearly readable', 'can not read',
                   '[not reported]', 'no code', '[no code]', '(empty)', '[empty]', 'cannot locate',
                   'to be completed', 'obscured', 'invisible', '[not yet identified]',
-                  'unidentified', 'not specified', 'not included', 'not noted',
+                  'unidentified', 'not specified', 'no specified', 'not included', 'not noted',
                   '[not provided by user]', 'not shown', 'still missing', 'none stated', 'absent',
-                   'n/a', 'undetermined', '(doesnt have one)', 'non-existend'])
+                  '[absent]', 'n/a', 'undetermined', '(doesnt have one)', 'non-existend',
+                  'no mould', 'no mould sid', 'no mould sid code', '(no mould sid code)',
+                  '[no mould sid code]', '"no mould sid code"', 'no mould sid-code',
+                  'no mould code', '(no mould code)', 'no ifpi', 'no ifpi code', 'unstated',
+                  '[blank]', 'unable to read', 'can\'t find', 'can\'t find it',
+                  'no code discernible', 'vacant', '[none observed]', 'indistinct',
+                  'information missing', 'no information', '(too faint to see)', 'without sid',
+                  'There is something on the innermost edge but it is unreadable'])
 
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
                            'VHS', 'DCC', 'Memory Stick', 'Edison Disc'])
@@ -106,12 +119,11 @@ SPARS_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None, '·': None,
                                  '∙': None, '᛫': None, '[': None, ']': None,
                                  '-': None, '|': None, '/': None, '\\': None})
 
-# Translation table for mastering SID codes
-# some people insist on using ƒ/⨍ instead of f
-# or ρ/ƥ instead of p
-MASTERING_SID_TRANSLATE = str.maketrans({' ': None, '-': None,
-                                        '⨍': 'f', 'ƒ': 'f',
-                                        'ρ': 'p', 'ƥ': 'p'})
+# Translation table for SID codes as some people
+# insist on using ƒ/⨍ instead of f or ρ/ƥ instead of p
+SID_TRANSLATE = str.maketrans({' ': None, '-': None,
+                              '⨍': 'f', 'ƒ': 'f',
+                              'ρ': 'p', 'ƥ': 'p'})
 
 # grab the current year. Make sure to set the clock of your machine
 # to the correct date or use NTP!
@@ -749,46 +761,6 @@ class DiscogsHandler():
                                     self.count += 1
                                     self.prev = self.release
                                     print("%8d -- ISRC (date earlier): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
-                if self.inmouldsid:
-                    # temporary hack, move to own configuration option
-                    mould_sid_strict = False
-                    if self.config['check_mould_sid']:
-                        if v.strip() == 'none':
-                            return
-                        # cleanup first for not so heavy formatting booboos
-                        mould_tmp = v.strip().lower().replace(' ', '')
-                        mould_tmp = mould_tmp.replace('-', '')
-                        # some people insist on using ƒ instead of f
-                        mould_tmp = mould_tmp.replace('ƒ', 'f')
-                        res = discogssmells.mouldsidre.match(mould_tmp)
-                        if res is None:
-                            self.count += 1
-                            self.prev = self.release
-                            print(f'{self.count:8} -- Mould SID Code (value): https://www.discogs.com/release/{self.release}')
-                            return
-                        if mould_sid_strict:
-                            mould_split = mould_tmp.split('ifpi', 1)[-1]
-                            for ch in ['i', 'o', 's', 'q']:
-                                if ch in mould_split[-2:]:
-                                    self.count += 1
-                                    self.prev = self.release
-                                    print('%8d -- Mould SID Code (strict value): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                    return
-                        # rough check to find SID codes for formats
-                        # other than CD/CD-like
-                        if len(self.formattexts) == 1:
-                            for fmt in SID_INVALID_FORMATS:
-                                if fmt in self.formattexts:
-                                    self.count += 1
-                                    self.prev = self.release
-                                    print('%8d -- Mould SID Code (Wrong Format: %s): https://www.discogs.com/release/%s' % (self.count, fmt, str(self.release)))
-                                    return
-                        if self.year is not None:
-                            if self.year < 1993:
-                                self.count += 1
-                                self.prev = self.release
-                                print('%8d -- Mould SID Code (wrong year): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                return
                 if self.country == 'India':
                     if self.config['check_pkd']:
                         if 'pkd' in v.lower() or "production date" in v.lower():
@@ -1415,8 +1387,8 @@ def main(cfg, datadump):
                                         value_lower = identifier.get('value').lower().strip()
                                         if value_lower not in SID_IGNORE:
                                             # cleanup first for not so heavy formatting booboos
-                                            master_tmp = value_lower.translate(MASTERING_SID_TRANSLATE)
-                                            res = discogssmells.masteringsidre.match(master_tmp)
+                                            master_sid_tmp = value_lower.translate(SID_TRANSLATE)
+                                            res = discogssmells.masteringsidre.match(master_sid_tmp)
                                             if res is None:
                                                 print_error(counter, f'Mastering SID Code (value: {value})', release_id)
                                                 counter += 1
@@ -1433,6 +1405,38 @@ def main(cfg, datadump):
                                                         print_error(counter, f'Mastering SID Code (wrong year: {year})', release_id)
                                                         counter += 1
 
+                                # Mould SID Code
+                                # temporary hack, move to own configuration option
+                                mould_sid_strict = False
+                                if config_settings.mould_sid:
+                                    if identifier_type == 'Mould SID Code':
+                                        value = identifier.get('value').strip()
+                                        value_lower = identifier.get('value').lower().strip()
+                                        if value_lower not in SID_IGNORE:
+                                            # cleanup first for not so heavy formatting booboos
+                                            mould_sid_tmp = value_lower.translate(SID_TRANSLATE)
+                                            res = discogssmells.mouldsidre.match(mould_sid_tmp)
+                                            if res is None:
+                                                print_error(counter, f'Mould SID Code (value: {value})', release_id)
+                                                counter += 1
+                                            else:
+                                                if mould_sid_strict:
+                                                    mould_split = mould_sid_tmp.split('ifpi', 1)[-1]
+                                                    for ch in ['i', 'o', 's', 'q']:
+                                                        if ch in mould_split[-2:]:
+                                                            print_error(counter, 'Mould SID Code (strict value)', release_id)
+                                                            counter += 1
+                                                # rough check to find SID codes for formats
+                                                # other than CD/CD-like
+                                                if len(formats) == 1:
+                                                    for fmt in SID_INVALID_FORMATS:
+                                                        if fmt in formats:
+                                                            print_error(counter, f'Mould SID Code (Wrong Format: {fmt})', release_id)
+                                                            counter += 1
+                                                if year is not None:
+                                                    if year < 1993:
+                                                        print_error(counter, f'Mould SID Code (wrong year: {year})', release_id)
+                                                        counter += 1
                                 # Rights Society
                                 if config_settings.rights_society:
                                     value = identifier.get('value')

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -608,6 +608,8 @@ def main(cfg, datadump, release_nr):
                     # skip the release if -r was passed on the command line
                     if release_nr is not None:
                         if release_nr != release_id:
+                            # reduce memory usage
+                            element.clear()
                             continue
 
                     # first see if a release is worth looking at
@@ -631,6 +633,13 @@ def main(cfg, datadump, release_nr):
 
                     # genres, currently not used in a check
                     genres = set()
+
+                    # first store the country to make sure it is always available
+                    # for for various country checks (like Czech misspellings)
+                    for child in element:
+                        if child.tag == 'country':
+                            country = child.text
+                            break
 
                     # and process the different elements
                     for child in element:
@@ -700,8 +709,6 @@ def main(cfg, datadump, release_nr):
                                                                 counter += 1
                                                                 break
 
-                        elif child.tag == 'country':
-                            country = child.text
                         elif child.tag == 'formats':
                             for release_format in child:
                                 current_format = None

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -941,10 +941,11 @@ def main(cfg, datadump, release_nr):
 
                                             # check the descriptions
                                             # TODO: match with the actual track list
-                                            if description_lower in isrc_descriptions_seen:
-                                                print_error(counter, f'ISRC code (description reuse: {description}', release_id)
-                                                counter += 1
-                                            isrc_descriptions_seen.add(description_lower)
+                                            if description_lower != '':
+                                                if description_lower in isrc_descriptions_seen:
+                                                    print_error(counter, f'ISRC code (description reuse: {description})', release_id)
+                                                    counter += 1
+                                                isrc_descriptions_seen.add(description_lower)
                                     else:
                                         # specifically check the description
                                         if description_lower.startswith('isrc'):

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -483,8 +483,6 @@ class DiscogsHandler():
                     self.inbarcode = True
                 elif v == 'ASIN':
                     self.inasin = True
-                elif v == 'Mastering SID Code':
-                    self.inmasteringsid = True
                 elif v == 'Mould SID Code':
                     self.inmouldsid = True
                 elif v == 'Matrix / Runout':
@@ -670,16 +668,6 @@ class DiscogsHandler():
                         self.count += 1
                         print('%8d -- ASIN (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                         return
-                if self.config['check_mastering_sid']:
-                    if not self.inmasteringsid:
-                        if self.description.strip() in discogssmells.masteringsids:
-                            self.count += 1
-                            print('%8d -- Mastering SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
-                        if self.description.strip() in ['sid code matrix', 'sid code - matrix', 'sid code (matrix)', 'sid-code, matrix', 'sid-code matrix', 'sid code (matrix ring)', 'sid code, matrix ring', 'sid code: matrix ring']:
-                            self.count += 1
-                            print('%8d -- Possible Mastering SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
                 if self.config['check_mould_sid']:
                     if not self.inmouldsid:
                         if self.description.strip() in discogssmells.mouldsids:
@@ -1278,6 +1266,13 @@ def main(cfg, datadump):
                                                     if year < 1993:
                                                         print_error(counter, f'Mastering SID Code (wrong year: {year})', release_id)
                                                         counter += 1
+                                    else:
+                                        if description_lower in discogssmells.masteringsids:
+                                            print_error(counter, 'Mastering SID Code', release_id)
+                                            counter += 1
+                                        elif description_lower in discogssmells.possible_mastering_sid:
+                                            print_error(counter, 'Possible Mastering SID Code', release_id)
+                                            counter += 1
 
                                 # Mould SID Code
                                 # temporary hack, move to own configuration option

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -474,7 +474,7 @@ def main(cfg, datadump, requested_release):
                                             break
 
                         if child.tag == 'artists' or child.tag == 'extraartists':
-                            if config_settings.artist or True:
+                            if config_settings.artist:
                                 for artist_elem in child:
                                     # set to "no artist" as a place holder
                                     artist_id = 0

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -65,21 +65,39 @@ RIGHTS_SOCIETY_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None})
 # some values that are not the actual data, but are metadata describing
 # something about the SID codes (readable, missing, and so on) or about
 # actions that need to be taken.
-SID_IGNORE = set(['none', '(none)', '[none]', '<none>', 'non', 'nond', 'none or hidden',
-                  'not present', '(not present)', '[not present]',
-                  'missing', '(missing)', '[missing]', '(missing info)', '[missing data]',
-                  '[not available]', 'unknown', '(unknown)', '[unknown]', 'unk',
-                  'not visible', 'none visible', 'non visible', 'none seen', 'none entered',
-                  'not entered', '[not entered]', '(not entered)', '(not entered))',
-                  '[nothing entered]', '[to be entered]', 'to be confirmed', '[?]', '[? ?]',
-                  '?', '???????', 'no', 'not recorded', '[not recorded]', 'not supplied',
-                  '[not supplied]', 'unreadable', '[unreadable]', '(unreadable)', '[not given]',
-                  'not added', 'none cited', 'not provided', 'not stated', '[not stated]',
+SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<none>', 'non',
+                  'nond', 'none found', 'none or hidden', 'not', 'not present', '(not present)',
+                  '[not present]', '<not present>', 'not present or not entered',
+                  '[not yet identified]', 'nothing', 'none / [missing]', 'missing', '(missing)',
+                  '[missing]', '(missing info)', '[missing data]', 'not available',
+                  '(not available)', '[not available]', 'not found', '(not found)', '[not found]',
+                  '(not found on cd)', 'missing / not found', '[indecipherable]',
+                  'not known', 'unknown', '(unknown)', '[unknown]', 'unk', 'not on disc',
+                  'not visible', '(not visible)', '[not visible]', 'none or not visible',
+                  'not visible on both cds', 'not visible (black cd)', 'not visable',
+                  'none visible', '[none visible]', 'non visible', 'none seen', '[none seen]',
+                  '[not seen]', 'not registered', 'none entered', 'not entered', '[not entered]',
+                  '(not entered', '(not entered)', '[nothing entered]', 'none or not entered',
+                  '(none or not entered)', 'not entered / none', '[not entered/none]',
+                  '... not entered ...', '[to be entered]', 'not entered or not present',
+                  'need to be entered', 'to be confirmed', '[?]', '[? ?]', '?', '??', '????', '???????',
+                  '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied'),
+                  '[not supplied]', 'unreadable', '[unreadable]', '(unreadable)',
+                  'unreadable/too small', 'not given',
+                  '(not given)', '[not given]', 'not inserted', '(not inserted)', '[not inserted]',
+                  'not added', '(not added)', '[not added]', '(to be added by another user)',
+                  'none cited', 'not provided', '(not provided)', 'not stated', '[not stated]',
                   'not submitted', '[not submitted]', '(not apparent)', '[not apparent]',
-                  'none apparent', 'illegible', 'no sid', 'no sid code', 'no sid codes',
-                  'not detectable', '[not discernable]', 'not readable', 'not clearly readable',
-                  '[not reported]', 'no code', '[no code]', '[empty]', 'cannot locate',
-                  'to be completed', 'obscured', 'invisible'])
+                  'none apparent', 'not legible', '[not legible]', 'illegible', '[illegible]',
+                  'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
+                  'not detectable', 'none or not detectable', '[not discernable]', 'not readable',
+                  '(not readable)', '[not readable]', '[none/not readable]', '[none / not readable]',
+                  'not readable (to small)', 'not clearly readable', 'can not read',
+                  '[not reported]', 'no code', '[no code]', '(empty)', '[empty]', 'cannot locate',
+                  'to be completed', 'obscured', 'invisible', '[not yet identified]',
+                  'unidentified', 'not specified', 'not included', 'not noted',
+                  '[not provided by user]', 'not shown', 'still missing', 'none stated', 'absent',
+                   'n/a', 'undetermined', '(doesnt have one)', 'non-existend'])
 
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
                            'VHS', 'DCC', 'Memory Stick', 'Edison Disc'])
@@ -89,10 +107,11 @@ SPARS_TRANSLATE = str.maketrans({'.': None, ' ': None, '•': None, '·': None,
                                  '-': None, '|': None, '/': None, '\\': None})
 
 # Translation table for mastering SID codes
-# some people insist on using ƒ instead of f
-# or ρ instead of p
+# some people insist on using ƒ/⨍ instead of f
+# or ρ/ƥ instead of p
 MASTERING_SID_TRANSLATE = str.maketrans({' ': None, '-': None,
-                                        'ƒ': 'f', 'ρ': 'p'})
+                                        '⨍': 'f', 'ƒ': 'f',
+                                        'ρ': 'p', 'ƥ': 'p'})
 
 # grab the current year. Make sure to set the clock of your machine
 # to the correct date or use NTP!

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -100,25 +100,6 @@ class CleanupConfig:
     url_in_html: bool = True
     year_valid: bool = False
 
-# a class with a handler for the SAX parser
-class DiscogsHandler():
-    def __init__(self, config_settings):
-        # many default settings
-        self.count = 0
-        self.config = config_settings
-        self.contentbuffer = ''
-
-    def startElement(self, name, attrs):
-        if self.inrole:
-            if self.noartist:
-                wrongrolefornoartist = True
-                for r in ['Other', 'Artwork By', 'Executive Producer', 'Photography', 'Written By']:
-                    if r in self.contentbuffer.strip():
-                        wrongrolefornoartist = False
-                        break
-                if wrongrolefornoartist:
-                    pass
-                    #print(self.contentbuffer.strip(), " -- https://www.discogs.com/release/%s" % str(self.release))
 
 def print_error(counter, reason, release_id):
     '''Helper method for printing errors'''
@@ -157,7 +138,6 @@ def check_rights_society(value):
     value = value.translate(RIGHTS_SOCIETY_TRANSLATE_QND)
     if value in discogssmells.rights_societies_wrong:
         errors.append(f"possible wrong value: {value}")
-        reported = True
 
     if value in discogssmells.rights_societies_wrong_char:
         errors.append(f"wrong character set: {value}")
@@ -458,6 +438,17 @@ def main(cfg, datadump, requested_release):
                                         elif artist.tag == 'name':
                                             artist_name = artist.text
                                         elif artist.tag == 'role':
+                                            '''
+                                            if artist_id == 0:
+                                                wrong_role_for_noartist = True
+                                                for r in ['Other', 'Artwork By', 'Executive Producer', 'Photography', 'Written By']:
+                                                    if r in artist.text.strip():
+                                                        wrong_role_for_noartist = False
+                                                        break
+                                                if wrong_role_for_noartist:
+                                                    pass
+                                                    #print(self.contentbuffer.strip(), " -- https://www.discogs.com/release/%s" % str(self.release))
+                                            '''
                                             if config_settings.credits:
                                                 role_data = artist.text
                                                 if role_data is None:

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -45,20 +45,20 @@ SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<n
                   'not present or not entered', '[not yet identified]', 'nothing',
                   'none / [missing]', 'missing', '(missing)', '?missing?', '"missing"',
                   '[missing]', '(missing info)', '[missing data]', '[missing or not entered]',
-                  'missing entry', 'not available', '(not available)', '[not available]', 'not found',
-                  '(not found)', '[not found]', '(not found on cd)', 'missing / not found',
-                  '[indecipherable]', '(indistinguishable)', 'not known', 'unknown', '(unknown)',
-                  '[unknown]', 'unk', 'not on disc', 'not visible', '(not visible)', '(not visble)',
-                  '[not visible]', 'not visible/present', 'none or not visible',
-                  'not visible on both cds', 'not visible (black cd)', 'not visable',
-                  'none visible', '[none visible]', 'non visible', '[no code visible]',
-                  '[none recorded]', '[none or missing]', 'none seen', '[none seen]', '[not seen]',
-                  'not registered', 'none detected', 'none entered', 'not entered',
-                  '[not entered]', '(not entered', '(not entered)', '[nothing entered]', 'not enterd',
-                  'none or not entered', '(none or not entered)', '[none or not entered]',
-                  'not entered / none', 'not entered or none', '(not entered or none)',
-                  '[not entered/none]', '... not entered ...', '[to be entered]',
-                  'not entered or not present', 'need to be entered',
+                  'missing entry', 'not available', '(not available)', '[not available]',
+                  'not found', '(not found)', '[not found]', '(not found on cd)',
+                  'missing / not found', '[indecipherable]', '(indistinguishable)', 'not known',
+                  'unknown', '(unknown)', '[unknown]', 'unk', 'not on disc', 'not visible',
+                  '(not visible)', '(not visble)', '[not visible]', 'not visible/present',
+                  'none or not visible', 'not visible on both cds', 'not visible (black cd)',
+                  'not visable', 'none visible', '[none visible]', 'non visible',
+                  '[no code visible]', '[none recorded]', '[none or missing]', 'none seen',
+                  '[none seen]', '[not seen]', 'not registered', 'none detected', 'none entered',
+                  'not entered', '[not entered]', '(not entered', '(not entered)',
+                  '[nothing entered]', 'not enterd', 'none or not entered', '(none or not entered)',
+                  '[none or not entered]', 'not entered / none', 'not entered or none',
+                  '(not entered or none)', '[not entered/none]', '... not entered ...',
+                  '[to be entered]', 'not entered or not present', 'need to be entered',
                   'to be confirmed', '[?]', '[? ?]', '?', '??', '???', '????', '???????',
                   '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied)',
                   '[not supplied]', 'none supplied', 'unreadable', '[unreadable]', '(unreadable)',
@@ -71,19 +71,20 @@ SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<n
                   'none apparent', 'apparently none', 'not legible', '[not legible]', 'illegible',
                   '[illegible]', 'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
                   'not detectable', 'none or not detectable', '[not discernable]', 'not readable',
-                  '(not readable)', '[not readable]', '[none/not readable]', '[none / not readable]',
-                  'not readable (to small)', 'not clearly readable', 'can not read',
-                  '[not reported]', 'no code', '[no code]', '(empty)', '[empty]', 'cannot locate',
-                  'to be completed', 'obscured', 'invisible', '[not yet identified]',
-                  'unidentified', 'not specified', 'no specified', 'not included', 'not noted',
-                  '[not provided by user]', 'not shown', 'still missing', 'none stated', 'absent',
-                  '[absent]', 'n/a', 'undetermined', '(doesnt have one)', 'non-existend',
-                  'no mould', 'no mould sid', 'no mould sid code', '(no mould sid code)',
-                  '[no mould sid code]', '"no mould sid code"', 'no mould sid-code',
-                  'no mould code', '(no mould code)', 'no ifpi', 'no ifpi code', 'unstated',
-                  '[blank]', 'unable to read', 'can\'t find', 'can\'t find it',
-                  'no code discernible', 'vacant', '[none observed]', 'indistinct',
-                  'information missing', 'no information', '(too faint to see)', 'without sid',
+                  '(not readable)', '[not readable]', '[none/not readable]',
+                  '[none / not readable]', 'not readable (to small)', 'not clearly readable',
+                  'can not read', '[not reported]', 'no code', '[no code]', '(empty)', '[empty]',
+                  'cannot locate', 'to be completed', 'obscured', 'invisible',
+                  '[not yet identified]', 'unidentified', 'not specified', 'no specified',
+                  'not included', 'not noted', '[not provided by user]', 'not shown',
+                  'still missing', 'none stated', 'absent', '[absent]', 'n/a', 'undetermined',
+                  '(doesnt have one)', 'non-existend', 'no mould', 'no mould sid',
+                  'no mould sid code', '(no mould sid code)', '[no mould sid code]',
+                  '"no mould sid code"', 'no mould sid-code', 'no mould code', '(no mould code)',
+                  'no ifpi', 'no ifpi code', 'unstated', '[blank]', 'unable to read',
+                  'can\'t find', 'can\'t find it', 'no code discernible', 'vacant',
+                  '[none observed]', 'indistinct', 'information missing', 'no information',
+                  '(too faint to see)', 'without sid',
                   'There is something on the innermost edge but it is unreadable'])
 
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
@@ -141,7 +142,6 @@ class CleanupConfig:
 class DiscogsHandler():
     def __init__(self, config_settings):
         # many default settings
-        self.debugcount = 0
         self.count = 0
         self.prev = None
         self.formattexts = set()
@@ -400,8 +400,6 @@ class DiscogsHandler():
             self.formatmaxqty = 0
             self.genres = set()
             self.tracklistpositions = set()
-            self.isrcpositions = set()
-            self.isrcseen = set()
             for (k, v) in attrs.items():
                 if k == 'id':
                     self.release = v
@@ -432,7 +430,6 @@ class DiscogsHandler():
                     if self.config['check_label_name']:
                         if v == 'London':
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Wrong label (London): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                 elif k == 'catno':
@@ -441,7 +438,6 @@ class DiscogsHandler():
                         if catno.startswith('lc'):
                             if discogssmells.labelcodere.match(catno) is not None:
                                 self.count += 1
-                                self.prev = self.release
                                 print('%8d -- Possible Label Code (in Catalogue Number): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                 return
                     if self.config['check_deposito']:
@@ -457,7 +453,6 @@ class DiscogsHandler():
 
                         if dlfound:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Possible Depósito Legal (in Catalogue Number): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
             self.labels.append((labelname, catno))
@@ -503,19 +498,15 @@ class DiscogsHandler():
                         return
                 if 'MADE IN USA BY PDMC' in v:
                     self.count += 1
-                    self.prev = self.release
                     print("%8d -- Matrix (PDMC instead of PMDC): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                 elif 'MADE IN GERMANY BY PDMC' in v:
                     self.count += 1
-                    self.prev = self.release
                     print("%8d -- Matrix (PDMC instead of PMDC): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                 elif 'MADE IN FRANCE BY PDMC' in v:
                     self.count += 1
-                    self.prev = self.release
                     print("%8d -- Matrix (PDMC instead of PMDC): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                 elif 'PDMC FRANCE' in v:
                     self.count += 1
-                    self.prev = self.release
                     print("%8d -- Matrix (PDMC instead of PMDC): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                 if self.config['check_creative_commons']:
                     if 'creative commons' in v.lower():
@@ -525,7 +516,7 @@ class DiscogsHandler():
                     if self.inmatrix:
                         if self.year is not None:
                             if 'MFG BY CINRAM' in v and '#' in v and 'USA' not in v:
-                                cinramres = re.search('#(\d{2})', v)
+                                cinramres = re.search(r'#(\d{2})', v)
                                 if cinramres is not None:
                                     cinramyear = int(cinramres.groups()[0])
                                     # correct the year. This won't work correctly after 2099.
@@ -535,15 +526,13 @@ class DiscogsHandler():
                                         cinramyear += 1900
                                     if cinramyear > currentyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Matrix (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif self.year < cinramyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Matrix (release date %d earlier than matrix year %d): https://www.discogs.com/release/%s" % (self.count, self.year, cinramyear, str(self.release)))
                             elif 'P+O' in v:
                                 # https://www.discogs.com/label/277449-PO-Pallas
-                                pallasres = re.search('P\+O[–-]\d{4,5}[–-][ABCD]\d?\s+\d{2}[–-](\d{2})', v)
+                                pallasres = re.search(r'P\+O[–-]\d{4,5}[–-][ABCD]\d?\s+\d{2}[–-](\d{2})', v)
                                 if pallasres is not None:
                                     pallasyear = int(pallasres.groups()[0])
                                     # correct the year. This won't work correctly after 2099.
@@ -553,11 +542,9 @@ class DiscogsHandler():
                                         pallasyear += 1900
                                     if pallasyear > currentyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Matrix (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif self.year < pallasyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Matrix (release date %d earlier than matrix year %d): https://www.discogs.com/release/%s" % (self.count, self.year, pallasyear, str(self.release)))
 
                 elif not self.inother:
@@ -570,7 +557,6 @@ class DiscogsHandler():
                             # possible SPARS codes
                             if tmpspars in discogssmells.validsparscodes:
                                 self.count += 1
-                                self.prev = self.release
                                 print('%8d -- SPARS Code (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                 return
                 elif not self.inother:
@@ -581,14 +567,12 @@ class DiscogsHandler():
                                 for r in discogssmells.rights_societies:
                                     if vsplit.upper().replace('.', '') == r or vsplit.upper().replace(' ', '') == r:
                                         self.count += 1
-                                        self.prev = self.release
                                         print('%8d -- Rights Society: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                         break
                         else:
                             for r in discogssmells.rights_societies:
                                 if v.upper().replace('.', '') == r or v.upper().replace(' ', '') == r:
                                     self.count += 1
-                                    self.prev = self.release
                                     print('%8d -- Rights Society: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                     break
                 if self.inbarcode:
@@ -597,7 +581,6 @@ class DiscogsHandler():
                             for depositovalre in discogssmells.depositovalres:
                                 if depositovalre.match(v.lower()) is not None:
                                     self.count += 1
-                                    self.prev = self.release
                                     print('%8d -- Depósito Legal (in Barcode): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                     return
                 if self.inasin:
@@ -610,7 +593,6 @@ class DiscogsHandler():
                             tmpasin = v
                         if not len(tmpasin.split(':')[-1].strip()) == 10:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- ASIN (wrong length): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                 if self.country == 'India':
@@ -618,7 +600,7 @@ class DiscogsHandler():
                         if 'pkd' in v.lower() or "production date" in v.lower():
                             if self.year is not None:
                                 # try a few variants
-                                pkdres = re.search("\d{1,2}/((?:19|20)?\d{2})", v)
+                                pkdres = re.search(r"\d{1,2}/((?:19|20)?\d{2})", v)
                                 if pkdres is not None:
                                     pkdyear = int(pkdres.groups()[0])
                                     if pkdyear < 100:
@@ -629,19 +611,15 @@ class DiscogsHandler():
                                             pkdyear += 1900
                                     if pkdyear < 1900:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif pkdyear > currentyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif self.year < pkdyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (release date earlier): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                             else:
                                 self.count += 1
-                                self.prev = self.release
                                 print('%8d -- India PKD code (no year): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                 return
             if 'description' in attritems:
@@ -664,92 +642,48 @@ class DiscogsHandler():
                         self.count += 1
                         print('%8d -- Creative Commons reference: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                 # squash repeated spaces
-                self.description = re.sub('\s+', ' ', self.description)
+                self.description = re.sub(r'\s+', ' ', self.description)
                 if self.config['check_rights_society']:
                     if not self.inrightssociety:
                         if self.description in discogssmells.rights_societies_ftf:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Rights Society: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             for rs in discogssmells.rights_societies_wrong_char:
                                 if rs in attrvalue:
                                     self.count += 1
-                                    self.prev = self.release
                                     print('%8d -- Rights Society (wrong character set, %s): https://www.discogs.com/release/%s' % (self.count, attrvalue, str(self.release)))
                             return
                 if self.config['check_label_code'] and not self.inlabelcode:
                     if self.description in discogssmells.label_code_ftf:
                         self.count += 1
-                        self.prev = self.release
                         print('%8d -- Label Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                         return
                 if self.config['check_spars_code']:
                     if not self.inspars:
-                        sparsfound = False
                         for spars in discogssmells.spars_ftf:
                             if spars in self.description:
-                                sparsfound = True
                                 self.count += 1
-                                self.prev = self.release
                                 print('%8d -- SPARS Code (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                 return
                 if self.config['check_asin']:
                     if not self.inasin and self.description.startswith('asin'):
                         self.count += 1
-                        self.prev = self.release
                         print('%8d -- ASIN (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                         return
-                if self.config['check_isrc']:
-                    if not self.inisrc:
-                        if self.description.startswith('isrc'):
-                            self.count += 1
-                            self.prev = self.release
-                            print('%8d -- ISRC Code (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
-                        if self.description.startswith('issrc'):
-                            self.count += 1
-                            self.prev = self.release
-                            print('%8d -- ISRC Code (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
-                        for isrc in discogssmells.isrc_ftf:
-                            if isrc in self.description:
-                                self.count += 1
-                                self.prev = self.release
-                                print('%8d -- ISRC Code (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                return
-                    else:
-                        if self.description.strip() in self.isrcpositions:
-                            self.count += 1
-                            self.prev = self.release
-                            print('%8d -- ISRC Code (description reuse %s): https://www.discogs.com/release/%s' % (self.count, self.description.strip(), str(self.release)))
-                        self.isrcpositions.add(self.description.strip())
                 if self.config['check_mastering_sid']:
                     if not self.inmasteringsid:
-                        if self.description.strip() in SID_DESCRIPTIONS:
-                            self.count += 1
-                            self.prev = self.release
-                            print('%8d -- Unspecified SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
                         if self.description.strip() in discogssmells.masteringsids:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Mastering SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                         if self.description.strip() in ['sid code matrix', 'sid code - matrix', 'sid code (matrix)', 'sid-code, matrix', 'sid-code matrix', 'sid code (matrix ring)', 'sid code, matrix ring', 'sid code: matrix ring']:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Possible Mastering SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                 if self.config['check_mould_sid']:
                     if not self.inmouldsid:
-                        if self.description.strip() in SID_DESCRIPTIONS:
-                            self.count += 1
-                            self.prev = self.release
-                            print('%8d -- Unspecified SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                            return
                         if self.description.strip() in discogssmells.mouldsids:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Mould SID Code: https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                 if self.country == 'Spain':
@@ -772,7 +706,6 @@ class DiscogsHandler():
 
                         if found:
                             self.count += 1
-                            self.prev = self.release
                             print('%8d -- Depósito Legal (BaOI): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                             return
                     else:
@@ -784,7 +717,7 @@ class DiscogsHandler():
                         if 'pkd' in self.description or "production date" in self.description:
                             if self.year is not None:
                                 # try a few variants
-                                pkdres = re.search("\d{1,2}/((?:19|20)?\d{2})", attrvalue)
+                                pkdres = re.search(r"\d{1,2}/((?:19|20)?\d{2})", attrvalue)
                                 if pkdres is not None:
                                     pkdyear = int(pkdres.groups()[0])
                                     if pkdyear < 100:
@@ -795,19 +728,15 @@ class DiscogsHandler():
                                             pkdyear += 1900
                                     if pkdyear < 1900:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif pkdyear > currentyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (impossible year): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     elif self.year < pkdyear:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Indian PKD (release date earlier): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                             else:
                                 self.count += 1
-                                self.prev = self.release
                                 print('%8d -- India PKD code (no year): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
                                 return
                 elif self.country == 'Czechoslovakia':
@@ -816,19 +745,17 @@ class DiscogsHandler():
                         strict_cs = False
                         if 'date' in self.description:
                             if self.year is not None:
-                                manufacturing_date_res = re.search("(\d{2})\s+\d$", attrvalue.rstrip())
+                                manufacturing_date_res = re.search(r"(\d{2})\s+\d$", attrvalue.rstrip())
                                 if manufacturing_date_res is not None:
                                     manufacturing_year = int(manufacturing_date_res.groups()[0])
                                     if manufacturing_year < 100:
                                         manufacturing_year += 1900
                                         if manufacturing_year > self.year:
                                             self.count += 1
-                                            self.prev = self.release
                                             print("%8d -- Czechoslovak manufacturing date (release year wrong): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                         # possibly this check makes sense, but not always
                                         elif manufacturing_year < self.year and strict_cs:
                                             self.count += 1
-                                            self.prev = self.release
                                             print("%8d -- Czechoslovak manufacturing date (release year possibly wrong): https://www.discogs.com/release/%s" % (self.count, str(self.release)))
 
                 elif self.country == 'Greece':
@@ -844,7 +771,6 @@ class DiscogsHandler():
                                         license_year += 1900
                                     if license_year > self.year:
                                         self.count += 1
-                                        self.prev = self.release
                                         print("%8d -- Greek license year wrong: https://www.discogs.com/release/%s" % (self.count, str(self.release)))
                                     licenseyearfound = True
                                 except:
@@ -1096,12 +1022,16 @@ def main(cfg, datadump):
 
                     # then store various things about the release
                     country = ""
-                    deposito_found = False
+                    deposito_found_in_notes = False
                     year = None
                     formats = set()
                     num_formats = 0
                     is_cd = False
+
+                    # data structures specific for detecting reuse of
+                    # ISRC codes and descriptions.
                     isrcs_seen = set()
+                    isrc_descriptions_seen = set()
 
                     # and process the different elements
                     for child in element:
@@ -1165,7 +1095,10 @@ def main(cfg, datadump):
                                 if country == 'Spain':
                                     if config_settings.deposito_legal:
                                         if identifier_type == 'Depósito Legal':
-                                            deposito_found = True
+                                            #deposito_found = True
+                                            if release_id == '34153':
+                                                print('BLAAT')
+                                                sys.exit(0)
                                             value = identifier.get('value')
                                             if value.endswith('.'):
                                                 print_error(counter, "Depósito Legal (formatting)", release_id)
@@ -1227,6 +1160,8 @@ def main(cfg, datadump):
 
                                 # ISRC
                                 if config_settings.isrc:
+                                    description = identifier.get('description', '').strip()
+                                    description_lower = description.lower()
                                     if identifier_type == 'ISRC':
                                         # Check the length of ISRC fields. According to the
                                         # specifications these should be 12 in length. Some
@@ -1280,6 +1215,27 @@ def main(cfg, datadump):
                                                 elif year < isrcyear:
                                                     print_error(counter, f'ISRC (date earlier: {isrcyear})', release_id)
                                                     counter += 1
+
+                                            # check the descriptions
+                                            # TODO: match with the actual track list
+                                            if description_lower in isrc_descriptions_seen:
+                                                print_error(counter, f'ISRC code (description reuse: {description}', release_id)
+                                                counter += 1
+                                            isrc_descriptions_seen.add(description_lower)
+                                    else:
+                                        # specifically check the description
+                                        if description_lower.startswith('isrc'):
+                                            print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                            counter += 1
+                                        elif description_lower.startswith('issrc'):
+                                            print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                            counter += 1
+                                        else:
+                                            for isrc in discogssmells.isrc_ftf:
+                                                if isrc in description_lower:
+                                                    print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                                    counter += 1
+                                                    break
                                 # Label Code
                                 if config_settings.label_code:
                                     value = identifier.get('value').lower()
@@ -1355,6 +1311,15 @@ def main(cfg, datadump):
                                                     if year < 1993:
                                                         print_error(counter, f'Mould SID Code (wrong year: {year})', release_id)
                                                         counter += 1
+
+                                # Mastering SID and Mould SID descriptions
+                                if config_settings.mastering_sid or config_settings.mould_sid:
+                                    description = identifier.get('description', '').strip()
+                                    description_lower = description.lower()
+                                    if description_lower in SID_DESCRIPTIONS:
+                                        print_error(counter, 'Unspecified SID Code', release_id)
+                                        counter += 1
+
                                 # Rights Society
                                 if config_settings.rights_society:
                                     value = identifier.get('value')
@@ -1411,6 +1376,7 @@ def main(cfg, datadump):
                                         if value_upper_translated in discogssmells.rights_societies:
                                             print_error(counter, f"Rights Society ('{value}', in {identifier_type})", release_id)
                                             counter += 1
+
                                 # SPARS Code
                                 if config_settings.spars:
                                     value = identifier.get('value')
@@ -1467,16 +1433,18 @@ def main(cfg, datadump):
                             #    print_error(counter, "Korean casino spam", release_id)
                             #    counter += 1
                             if country == 'Spain':
-                                if config_settings.deposito_legal and not deposito_found:
+                                if release_id == '34153':
+                                    print(deposito_found_in_notes)
+                                if config_settings.deposito_legal:
                                     # sometimes "deposito legal" can be found
                                     # in the "notes" section.
                                     content_lower = child.text.lower()
                                     for d in discogssmells.depositores:
                                         result = d.search(content_lower)
                                         if result is not None:
+                                            deposito_found_in_notes = True
                                             print_error(counter, "Depósito Legal (Notes)", release_id)
                                             counter += 1
-                                            found = True
                                             break
 
                             # see https://support.discogs.com/en/support/solutions/articles/13000014661-how-can-i-format-text-
@@ -1486,9 +1454,9 @@ def main(cfg, datadump):
                                     counter += 1
                             if config_settings.creative_commons:
                                 cc_found = False
-                                for cc in discogssmells.creativecommons:
-                                    if cc in child.text:
-                                        print_error(counter, f"Creative Commons reference ({cc})", release_id)
+                                for cc_ref in discogssmells.creativecommons:
+                                    if cc_ref in child.text:
+                                        print_error(counter, f"Creative Commons reference ({cc_ref})", release_id)
                                         counter += 1
                                         cc_found = True
                                         break

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -856,7 +856,7 @@ def main(cfg, datadump, release_nr):
                                     else:
                                         description = identifier.get('description', '').strip()
                                         if description.startswith('asin'):
-                                            print_errr(counter, f'ASIN (in {identifier})', release_id)
+                                            print_error(counter, f'ASIN (in {identifier})', release_id)
                                             counter += 1
 
                                 # Depósito Legal, only check for releases from Spain
@@ -1025,15 +1025,15 @@ def main(cfg, datadump, release_nr):
                                     else:
                                         # specifically check the description
                                         if description_lower.startswith('isrc'):
-                                            print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                            print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
                                             counter += 1
                                         elif description_lower.startswith('issrc'):
-                                            print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                            print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
                                             counter += 1
                                         else:
                                             for isrc in discogssmells.isrc_ftf:
                                                 if isrc in description_lower:
-                                                    print_error(counter, f'ISRC Code (in {identifier})', release_id)
+                                                    print_error(counter, f'ISRC Code (in {identifier_type})', release_id)
                                                     counter += 1
                                                     break
                                 # Label Code
@@ -1160,7 +1160,7 @@ def main(cfg, datadump, release_nr):
                                                         counter += 1
                                     else:
                                         if description_lower in discogssmells.mouldsids:
-                                            print_error(counter, f'Mould SID Code (in {identifier})', release_id)
+                                            print_error(counter, f'Mould SID Code (in {identifier_type})', release_id)
                                             counter += 1
 
                                 # Mastering SID and Mould SID descriptions

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -1309,7 +1309,7 @@ def main(cfg, datadump):
                             for identifier in child:
                                 identifier_type = identifier.get('type')
 
-                                # Depósito Legal, only for Spain
+                                # Depósito Legal, only check for releases from Spain
                                 if country == 'Spain':
                                     if config_settings.deposito_legal:
                                         if identifier_type == 'Depósito Legal':
@@ -1353,10 +1353,10 @@ def main(cfg, datadump):
                                                 # TODO, also allow (year), example: https://www.discogs.com/release/265497
                                                 if deposito_year is not None:
                                                     if deposito_year < 1900:
-                                                        print_error(counter, "Depósito Legal (impossible year)", release_id)
+                                                        print_error(counter, f"Depósito Legal (impossible year: {deposito_year})", release_id)
                                                         counter += 1
                                                     elif deposito_year > currentyear:
-                                                        print_error(counter, "Depósito Legal (impossible year)", release_id)
+                                                        print_error(counter, f"Depósito Legal (impossible year: {deposito_year})", release_id)
                                                         counter += 1
                                                     elif year < deposito_year:
                                                         print_error(counter, "Depósito Legal (release date earlier)", release_id)
@@ -1409,10 +1409,10 @@ def main(cfg, datadump):
                                                 print_error(counter, f"Rights Society (in {identifier_type})", release_id)
                                                 counter += 1
                                                 break
-                                # SPARS
-                                if config_settings.rights_society:
+                                # SPARS Code
+                                if config_settings.spars:
+                                    value = identifier.get('value')
                                     if identifier_type == 'SPARS Code':
-                                        value = identifier.get('value')
                                         if value != 'none':
                                             # Sony format codes
                                             # https://www.discogs.com/forum/thread/339244
@@ -1454,6 +1454,10 @@ def main(cfg, datadump):
                                                     for error in errors:
                                                         print_error(counter, f"SPARS Code ({error})", release_id)
                                                         counter += 1
+                                    else:
+                                        if value.lower() in discogssmells.validsparscodes:
+                                            print_error(counter, f"SPARS Code ({value}, in {identifier_type})", release_id)
+                                            counter += 1
                         elif child.tag == 'notes':
                             #if '카지노' in child.text:
                             #    # Korean casino spam that used to pop up

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -119,39 +119,6 @@ class DiscogsHandler():
                 if wrongrolefornoartist:
                     pass
                     #print(self.contentbuffer.strip(), " -- https://www.discogs.com/release/%s" % str(self.release))
-        elif self.inartistid:
-            if self.config['check_artist']:
-                if self.contentbuffer == '0':
-                    self.noartist = True
-                else:
-                    self.noartist = False
-                # TODO: check for genres, as No Artist is
-                # often confused with Unknown Artist
-                #if self.contentbuffer == '118760':
-                #    if len(self.genres) != 0:
-                #        print("https://www.discogs.com/artist/%s" % self.contentbuffer, "https://www.discogs.com/release/%s" % str(self.release))
-                #        print(self.genres)
-                #        sys.exit(0)
-            '''
-            # https://en.wikipedia.org/wiki/Phonograph_record#Microgroove_and_vinyl_era
-            if 'Vinyl' in self.formattexts:
-                if self.year is not None:
-                    if self.year < 1948:
-                        print('%8d -- Impossible year (%d): https://www.discogs.com/release/%s' % (self.count, self.year, str(self.release)))
-            '''
-        # now reset some values
-        self.contentbuffer = ''
-        self.inartistid = False
-
-        if name == 'artist':
-            self.inartist = True
-            self.noartist = False
-        if name == 'id':
-            if self.inartist:
-                self.inartistid = True
-                self.noartist = False
-        elif name == 'role':
-            self.inrole = True
 
 def print_error(counter, reason, release_id):
     '''Helper method for printing errors'''
@@ -482,6 +449,12 @@ def main(cfg, datadump, requested_release):
                                     for artist in artist_elem:
                                         if artist.tag == 'id':
                                             artist_id = int(artist.text)
+                                            # TODO: check for genres, as No Artist is
+                                            # often confused with Unknown Artist
+                                            #if artist_id == 118760:
+                                            #    if genres:
+                                            #        print_error(counter, f'https://www.discogs.com/artist/{artist_id}' release_id)
+                                            #        counter += 1
                                         elif artist.tag == 'name':
                                             artist_name = artist.text
                                         elif artist.tag == 'role':
@@ -576,6 +549,13 @@ def main(cfg, datadump, requested_release):
                                             is_cd = True
                                         formats.add(value)
                                         current_format = value
+                                        '''
+                                        # https://en.wikipedia.org/wiki/Phonograph_record#Microgroove_and_vinyl_era
+                                        if current_format == 'Vinyl' and year is not None:
+                                            if year < 1948:
+                                                print(counter, f'Impossible year '{year}' for vinyl', release_id)
+                                                counter += 1
+                                        '''
                                     elif key == 'qty':
                                         if num_formats == 0:
                                             num_formats = max(num_formats, int(value))

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -1256,27 +1256,26 @@ def main(cfg, datadump, requested_release):
                                 tracklist_positions = set()
                                 tracklist_correct = True
                                 if len(formats) == 1:
+                                    recorded_format = list(formats)[0]
                                     for track in child:
                                         for track_elem in track:
                                             if track_elem.tag == 'position':
                                                 if track_elem.text not in [None, '', '-']:
                                                     if num_formats == 1:
                                                         if track_elem.text in tracklist_positions:
-                                                            print_error(counter, f'Tracklisting reuse ({list(formats)[0]}, {track_elem.text})', release_id)
+                                                            print_error(counter, f'Tracklisting reuse ({recorded_format}, {track_elem.text})', release_id)
                                                             counter += 1
                                                     tracklist_positions.add(track_elem.text)
 
                                                     if tracklist_correct:
-                                                        for recorded_format in TRACKLIST_CHECK_FORMATS:
-                                                            if recorded_format in formats:
-                                                                try:
-                                                                    int(track_elem.text)
-                                                                    print_error(counter, f'Tracklisting uses numbers ({recorded_format})', release_id)
-                                                                    counter += 1
-                                                                    tracklist_correct = False
-                                                                    break
-                                                                except ValueError:
-                                                                    pass
+                                                        if recorded_format in TRACKLIST_CHECK_FORMATS:
+                                                            try:
+                                                                int(track_elem.text)
+                                                                print_error(counter, f'Tracklisting uses numbers ({recorded_format})', release_id)
+                                                                counter += 1
+                                                                tracklist_correct = False
+                                                            except ValueError:
+                                                                pass
 
                         if prev_counter != counter:
                             last_release_checked = release_id

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -65,6 +65,7 @@ pkd_re = re.compile(r"\d{1,2}/((?:19|20)?\d{2})")
 @dataclass
 class CleanupConfig:
     '''Default cleanup configuration'''
+    #artist: bool = False
     artist: bool = True
     asin: bool = True
     cd_plus_g: bool = True
@@ -420,7 +421,7 @@ def main(cfg, datadump, requested_release):
     except:
         pass
 
-    # store settings for artists, default True
+    # store settings for artists, default False
     try:
         config_settings.artist = config.getboolean('cleanup', 'artist')
     except:
@@ -550,7 +551,15 @@ def main(cfg, datadump, requested_release):
                                         if czech_error_found:
                                             break
 
-                        if child.tag == 'companies':
+                        if child.tag == 'artists' or child.tag == 'extraartists':
+                            if config_settings.artist:
+                                for artist_elem in child:
+                                    for artist in artist_elem:
+                                        if artist.tag == 'id':
+                                            if artist.text == '0':
+                                                print_error(counter, 'Artist not in database', release_id)
+                                                counter += 1
+                        elif child.tag == 'companies':
                             if year is not None:
                                 for companies in child:
                                     for company in companies:
@@ -1244,6 +1253,7 @@ def main(cfg, datadump, requested_release):
                                         counter += 1
 
                         elif child.tag == 'tracklist':
+                            # check artists and extraartists here TODO
                             if config_settings.tracklisting:
                                 # various tracklist sanity checks, but only if there is
                                 # only a single format to make things easier. This should be

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -31,8 +31,9 @@ ISRC_TRANSLATE = str.maketrans({'-': None, ' ': None, '.': None,
 
 # a list of possible label code false positives. These are
 # used when checking the catalog numbers.
-LABEL_CODE_FALSE_POSITIVES = set([654, 1005, 1060, 11358, 20234, 22804, 29480, 38653,
-                                  39161, 54361, 97031, 113617, 163947])
+LABEL_CODE_FALSE_POSITIVES = set([654, 1005, 1060, 5320, 11358, 20234, 22804, 29480, 38653,
+                                  39161, 54361, 63510, 97031, 113617, 127100, 163947,
+                                  199380, 487381, 498544])
 
 RIGHTS_SOCIETY_DELIMITERS = ['/', '|', '\\', '-', '—', '•', '·', ',', ':', ' ', '&', '+']
 

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -71,6 +71,7 @@ class CleanupConfig:
     creative_commons: bool = False
     credits: bool = False
     czechoslovak_dates: bool = True
+    czechoslovak_dates_strict: bool = False
     czechoslovak_spelling: bool = True
     debug: bool = False
     deposito_legal: bool = True
@@ -386,6 +387,12 @@ def main(cfg, datadump, requested_release):
     except:
         pass
 
+    # check for Czechoslovak manufacturing dates
+    try:
+        config_settings.czechoslovak_dates_strict = config.getboolean('cleanup', 'manufacturing_date_cs_strict')
+    except:
+        pass
+
     # check for Czechoslovak and Czech spelling (0x115 used instead of 0x11B)
     try:
         config_settings.czechoslovak_spelling = config.getboolean('cleanup', 'spelling_cs')
@@ -471,7 +478,7 @@ def main(cfg, datadump, requested_release):
                             # reduce memory usage
                             element.clear()
                             continue
-                        elif requested_release < release_id:
+                        if requested_release < release_id:
                             print(f'Release {requested_release} cannot be found in data set!',
                                   file=sys.stderr)
                             sys.exit(1)
@@ -683,9 +690,6 @@ def main(cfg, datadump, requested_release):
 
                                 if country == 'Czechoslovakia' and year is not None:
                                     if config_settings.config_settings.czechoslovak_dates:
-                                        # config hack, needs to be in its own configuration option
-                                        strict_cs = False
-
                                         description = identifier.get('description', '').strip().lower()
                                         value = identifier.get('value', '').strip().lower()
                                         if 'date' in description:
@@ -698,7 +702,7 @@ def main(cfg, datadump, requested_release):
                                                         print_error(counter, 'Czechoslovak manufacturing date (release year wrong)', release_id)
                                                         counter += 1
                                                     # possibly this check makes sense, but not always
-                                                    elif manufacturing_year < year and strict_cs:
+                                                    elif manufacturing_year < year and config_settings.czechoslovak_dates_strict:
                                                         print_error(counter, 'Czechoslovak manufacturing date (release year possibly wrong)', release_id)
                                                         counter += 1
 

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -36,57 +36,6 @@ RIGHTS_SOCIETY_TRANSLATE_QND = str.maketrans({'.': None, ' ': None, '•': None,
                                               '[': None, ']': None, '(': None,
                                               ')': None})
 
-# some values that are not the actual data, but are metadata describing
-# something about the SID codes (readable, missing, and so on) or about
-# actions that need to be taken.
-SID_IGNORE = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<none>', '\'none\'',
-                  'none.', 'non', 'nond', 'none found', 'none or hidden', 'none given', 'not',
-                  'not present', '(not present)', '[not present]', '<not present>',
-                  'not present or not entered', '[not yet identified]', 'nothing',
-                  'none / [missing]', 'missing', '(missing)', '?missing?', '"missing"',
-                  '[missing]', '(missing info)', '[missing data]', '[missing or not entered]',
-                  'missing entry', 'not available', '(not available)', '[not available]',
-                  'not found', '(not found)', '[not found]', '(not found on cd)',
-                  'missing / not found', '[indecipherable]', '(indistinguishable)', 'not known',
-                  'unknown', '(unknown)', '[unknown]', 'unk', 'not on disc', 'not visible',
-                  '(not visible)', '(not visble)', '[not visible]', 'not visible/present',
-                  'none or not visible', 'not visible on both cds', 'not visible (black cd)',
-                  'not visable', 'none visible', '[none visible]', 'non visible',
-                  '[no code visible]', '[none recorded]', '[none or missing]', 'none seen',
-                  '[none seen]', '[not seen]', 'not registered', 'none detected', 'none entered',
-                  'not entered', '[not entered]', '(not entered', '(not entered)',
-                  '[nothing entered]', 'not enterd', 'none or not entered', '(none or not entered)',
-                  '[none or not entered]', 'not entered / none', 'not entered or none',
-                  '(not entered or none)', '[not entered/none]', '... not entered ...',
-                  '[to be entered]', 'not entered or not present', 'need to be entered',
-                  'to be confirmed', '[?]', '[? ?]', '?', '??', '???', '????', '???????',
-                  '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied)',
-                  '[not supplied]', 'none supplied', 'unreadable', '[unreadable]', '(unreadable)',
-                  'unreadable/too small', 'none or unreadable', 'nil', 'not given',
-                  '(not given)', '[not given]', 'not inserted', '(not inserted)', '[not inserted]',
-                  'not added', '(not added)', '[not added]', '[not added yet]',
-                  '(to be added by another user)', 'none cited', 'not provided', '(not provided)',
-                  'not stated', '[not stated]', 'not submitted', '[not submitted]',
-                  '[not submittted]', '(not apparent)', '[not apparent]', '<not apparent>',
-                  'none apparent', 'apparently none', 'not legible', '[not legible]', 'illegible',
-                  '[illegible]', 'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
-                  'not detectable', 'none or not detectable', '[not discernable]', 'not readable',
-                  '(not readable)', '[not readable]', '[none/not readable]',
-                  '[none / not readable]', 'not readable (to small)', 'not clearly readable',
-                  'can not read', '[not reported]', 'no code', '[no code]', '(empty)', '[empty]',
-                  'cannot locate', 'to be completed', 'obscured', 'invisible',
-                  '[not yet identified]', 'unidentified', 'not specified', 'no specified',
-                  'not included', 'not noted', '[not provided by user]', 'not shown',
-                  'still missing', 'none stated', 'absent', '[absent]', 'n/a', 'undetermined',
-                  '(doesnt have one)', 'non-existend', 'no mould', 'no mould sid',
-                  'no mould sid code', '(no mould sid code)', '[no mould sid code]',
-                  '"no mould sid code"', 'no mould sid-code', 'no mould code', '(no mould code)',
-                  'no ifpi', 'no ifpi code', 'unstated', '[blank]', 'unable to read',
-                  'can\'t find', 'can\'t find it', 'no code discernible', 'vacant',
-                  '[none observed]', 'indistinct', 'information missing', 'no information',
-                  '(too faint to see)', 'without sid',
-                  'There is something on the innermost edge but it is unreadable'])
-
 SID_INVALID_FORMATS = set(['Vinyl', 'Cassette', 'Shellac', 'File',
                            'VHS', 'DCC', 'Memory Stick', 'Edison Disc'])
 
@@ -1247,7 +1196,7 @@ def main(cfg, datadump):
                                     if identifier_type == 'Mastering SID Code':
                                         value = identifier.get('value').strip()
                                         value_lower = identifier.get('value').lower().strip()
-                                        if value_lower not in SID_IGNORE:
+                                        if value_lower not in discogssmells.sid_ignore:
                                             # cleanup first for not so heavy formatting booboos
                                             master_sid_tmp = value_lower.translate(SID_TRANSLATE)
                                             res = discogssmells.masteringsidre.match(master_sid_tmp)
@@ -1281,7 +1230,7 @@ def main(cfg, datadump):
                                     if identifier_type == 'Mould SID Code':
                                         value = identifier.get('value').strip()
                                         value_lower = identifier.get('value').lower().strip()
-                                        if value_lower not in SID_IGNORE:
+                                        if value_lower not in discogssmells.sid_ignore:
                                             # cleanup first for not so heavy formatting booboos
                                             mould_sid_tmp = value_lower.translate(SID_TRANSLATE)
                                             res = discogssmells.mouldsidre.match(mould_sid_tmp)

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -841,10 +841,6 @@ def main(cfg, datadump, release_nr):
             except:
                 pass
 
-    # keep a mapping for the 'identifiers' item, detailing which
-    # item belongs where
-    identifier_mapping = {'barcode', 'Barcode'}
-
     try:
         with gzip.open(datadump, "rb") as dumpfile:
             counter = 1

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -97,7 +97,7 @@ class CleanupConfig:
     year_valid: bool = False
 
 # a class with a handler for the SAX parser
-class discogs_handler():
+class DiscogsHandler():
     def __init__(self, config_settings):
         # many default settings
         self.inrole = False
@@ -126,7 +126,7 @@ class discogs_handler():
         self.debugcount = 0
         self.count = 0
         self.prev = None
-        self.formattexts = set([])
+        self.formattexts = set()
         self.iscd = False
         self.depositofound = False
         self.labels = []
@@ -412,11 +412,11 @@ class discogs_handler():
             self.inartistid = False
             self.noartist = False
             self.ingenre = False
-            self.formattexts = set([])
-            self.artists = set([])
+            self.formattexts = set()
+            self.artists = set()
             self.labels = []
             self.formatmaxqty = 0
-            self.genres = set([])
+            self.genres = set()
             self.tracklistpositions = set()
             self.isrcpositions = set()
             self.isrcseen = set()
@@ -492,47 +492,6 @@ class discogs_handler():
             self.intitle = True
         elif name == 'position':
             self.inposition = True
-        elif name == 'format':
-            curformat = None
-            for (k, v) in attrs.items():
-                if k == 'name':
-                    if v == 'CD':
-                        self.iscd = True
-                    self.formattexts.add(v)
-                    curformat = v
-                elif k == 'qty':
-                    if self.formatmaxqty == 0:
-                        self.formatmaxqty = max(self.formatmaxqty, int(v))
-                    else:
-                        self.formatmaxqty += int(v)
-                elif k == 'text':
-                    if v != '':
-                        if self.config['check_spars_code']:
-                            tmpspars = v.lower().strip()
-                            for s in ['.', ' ', '•', '·', '[', ']', '-', '|', '/']:
-                                tmpspars = tmpspars.replace(s, '')
-                            if tmpspars in discogssmells.validsparscodes:
-                                self.count += 1
-                                self.prev = self.release
-                                print('%8d -- Possible SPARS Code (in Format): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                return
-                        if self.config['check_label_code']:
-                            if v.lower().startswith('lc'):
-                                if discogssmells.labelcodere.match(v.lower()) is not None:
-                                    self.count += 1
-                                    self.prev = self.release
-                                    print('%8d -- Possible Label Code (in Format): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                    return
-                        if self.config['check_cdg']:
-                            if v.lower().strip() == 'cd+g':
-                                self.count += 1
-                                self.prev = self.release
-                                print('%8d -- CD+G (in Format): https://www.discogs.com/release/%s' % (self.count, str(self.release)))
-                                return
-                        if v == 'DMM':
-                            if curformat != 'Vinyl':
-                                print('%8d -- DMM (%s, in Format): https://www.discogs.com/release/%s' % (self.count, curformat, str(self.release)))
-
         elif name == 'description':
             self.indescription = True
         elif name == 'identifier':
@@ -1201,57 +1160,50 @@ def main(cfg, datadump):
             # store settings for CD+G checks
             try:
                 config_settings.cd_plus_g = config.getboolean(section, 'cdg')
-            except Exception:
+            except:
                 pass
 
             # store settings for Matrix checks
             try:
-                if config.get(section, 'matrix') != 'yes':
-                    config_settings.matrix = False
-            except Exception:
+                config_settings.matrix = config.getboolean(section, 'matrix')
+            except:
                 pass
 
             # store settings for label checks
             try:
-                if config.get(section, 'labels') != 'yes':
-                    config_settings.labels = False
-            except Exception:
+                config_settings.labels = config.getboolean(section, 'labels')
+            except:
                 pass
 
             # store settings for manufacturing plant checks
             try:
-                if config.get(section, 'plants') != 'yes':
-                    config_settings.manufacturing_plants = False
-            except Exception:
+                config_settings.manufacturing_plants = config.getboolean(section, 'plants')
+            except:
                 pass
 
             # check for Czechoslovak manufacturing dates
             try:
-                if config.get(section, 'manufacturing_date_cs') != 'yes':
-                    config_settings.czechoslovak_dates = False
-            except Exception:
+                config_settings.czechoslovak_dates = config.getboolean(section, 'manufacturing_date_cs')
+            except:
                 pass
 
             # check for Czechoslovak and Czech spelling
             # (0x115 used instead of 0x11B)
             try:
-                if config.get(section, 'spelling_cs') != 'yes':
-                    config_settings.czechoslovak_spelling = False
-            except Exception:
+                config_settings.czechoslovak_spelling = config.getboolean(section, 'spelling_cs')
+            except:
                 pass
 
             # store settings for tracklisting checks, default True
             try:
-                if config.get(section, 'tracklisting') != 'yes':
-                    config_settings.tracklisting = False
-            except Exception:
+                config_settings.tracklisting = config.getboolean(section, 'tracklisting')
+            except:
                 pass
 
             # store settings for artists, default True
             try:
-                if config.get(section, 'artist') != 'yes':
-                    config_settings.artist = False
-            except Exception:
+                config_settings.artist = config.getboolean(section, 'artist')
+            except:
                 pass
 
             # store settings for credits list checks
@@ -1263,49 +1215,43 @@ def main(cfg, datadump):
                         # TODO: fix
                         config_settings.creditsfile = creditsfile
                         config_settings.credits = True
-            except Exception:
+            except:
                 pass
 
             # store settings for URLs in Notes checks
             try:
-                if config.get(section, 'html') != 'yes':
-                    config_settings.url_in_html = False
-            except Exception:
+                config_settings.url_in_html = config.getboolean(section, 'html')
+            except:
                 pass
 
             # month is 00 check: default is False
             try:
-                if config.get(section, 'month') == 'yes':
-                    config_settings.month_valid = True
-            except Exception:
+                config_settings.month_valid = config.getboolean(section, 'month')
+            except:
                 pass
 
             # year is wrong check: default is False
             try:
-                if config.get(section, 'year') == 'yes':
-                    config_settings.year_valid = True
-            except Exception:
+                config_settings.year_valid = config.getboolean(section, 'year')
+            except:
                 pass
 
             # reporting all: default is False
             try:
-                if config.get(section, 'reportall') == 'yes':
-                    config_settings.report_all = True
-            except Exception:
+                config_settings.report_all = config.getboolean(section, 'reportall')
+            except:
                 pass
 
             # debug: default is False
             try:
-                if config.get(section, 'debug') == 'yes':
-                    config_settings.debug = True
-            except Exception:
+                config_settings.debug = config.getboolean(section, 'debug')
+            except:
                 pass
 
             # report creative commons references: default is False
             try:
-                if config.get(section, 'creative_commons') == 'yes':
-                    config_settings.creative_commons = True
-            except Exception:
+                config_settings.creative_commons = config.getboolean(section, 'creative_commons')
+            except:
                 pass
 
     # keep a mapping for the 'identifiers' item, detailing which
@@ -1320,7 +1266,7 @@ def main(cfg, datadump):
                     # first see if a release is worth looking at
                     status = element.get('status')
                     if status in ['Deleted', 'Draft', 'Rejected']:
-                        break
+                        continue
 
                     # store the release id
                     release_id = element.get('id')
@@ -1329,10 +1275,52 @@ def main(cfg, datadump):
                     country = ""
                     deposito_found = False
                     year = None
+                    formats = set()
+                    num_formats = 0
+                    is_cd = False
 
+                    # and process the different elements
                     for child in element:
                         if child.tag == 'country':
                             country = child.text
+                        elif child.tag == 'formats':
+                            for release_format in child:
+                                current_format = None
+                                for (key, value) in release_format.items():
+                                    if key == 'name':
+                                        if value == 'CD':
+                                            is_cd = True
+                                        formats.add(value)
+                                        current_format = value
+                                    elif key == 'qty':
+                                        if num_formats == 0:
+                                            num_formats = max(num_formats, int(value))
+                                        else:
+                                            num_formats += int(value)
+                                    elif key == 'text':
+                                        if value != '':
+                                            value_lower = value.lower().strip()
+                                            if config_settings.spars:
+                                                tmpspars = value_lower
+                                                for s in ['.', ' ', '•', '·', '[', ']', '-', '|', '/']:
+                                                    tmpspars = tmpspars.replace(s, '')
+                                                if tmpspars in discogssmells.validsparscodes:
+                                                    print_error(counter, "Possible SPARS Code (in Format)", release_id)
+                                                    counter += 1
+                                            if config_settings.label_code:
+                                                if value_lower.startswith('lc'):
+                                                    if discogssmells.labelcodere.match(value_lower) is not None:
+                                                        print_error(counter, "Possible Label Code (in Format)", release_id)
+                                                        counter += 1
+                                            if config_settings.cd_plus_g:
+                                                if value_lower == 'cd+g':
+                                                    print_error(counter, f'CD+G (in Format)', release_id)
+                                                    counter += 1
+                                            if value_lower == 'DMM':
+                                                if current_format != 'Vinyl':
+                                                    print_error(f'DMM ({current_format}, in Format)', release_id)
+                                                    counter += 1
+
                         elif child.tag == 'identifiers':
                             # Here things get very hairy, as every check
                             # potentially has to be done multiple times: once
@@ -1349,6 +1337,7 @@ def main(cfg, datadump):
                                 # Depósito Legal, only for Spain
                                 if config_settings.deposito_legal:
                                     if identifier_type == 'Depósito Legal':
+                                        deposito_found = True
                                         if country == 'Spain':
                                             value = identifier.get('value')
                                             if value.endswith('.'):
@@ -1383,7 +1372,7 @@ def main(cfg, datadump):
                                                             else:
                                                                 deposito_year += 1900
                                                         break
-                                                    except:
+                                                    except ValueError:
                                                         pass
 
                                                 # TODO, also allow (year), example: https://www.discogs.com/release/265497
@@ -1448,10 +1437,15 @@ def main(cfg, datadump):
                                     pass
                                     #print(identifier.items())
                         elif child.tag == 'notes':
+                            #if '카지노' in child.text:
+                            #    # Korean casino spam that used to pop up
+                            #    # every once in a while.
+                            #    print_error(counter, "Korean casino spam", release_id)
+                            #    counter += 1
                             if country == 'Spain':
                                 if config_settings.deposito_legal and not deposito_found:
                                     # sometimes "deposito legal" can be found
-                                    # in the "notes" section
+                                    # in the "notes" section.
                                     content_lower = child.text.lower()
                                     for d in discogssmells.depositores:
                                         result = d.search(content_lower)
@@ -1466,10 +1460,6 @@ def main(cfg, datadump):
                                 if '&lt;a href="http://www.discogs.com/release/' not in child.text:
                                     print_error(counter, "old link (Notes)", release_id)
                                     counter += 1
-                            if '카지노' in child.text:
-                                # Korean casino spam that pops up every once in a while
-                                print_error(counter, "Korean casino spam", release_id)
-                                counter += 1
                             if config_settings.creative_commons:
                                 cc_found = False
                                 for cc in discogssmells.creativecommons:
@@ -1499,7 +1489,7 @@ def main(cfg, datadump):
                             if child.text != '':
                                 try:
                                     year = int(child.text.split('-', 1)[0])
-                                except:
+                                except ValueError:
                                     if config_settings.year_valid:
                                         print_error(counter, f"Year {child.text} invalid", release_id)
                                         counter += 1

--- a/cleanup-discogs.py
+++ b/cleanup-discogs.py
@@ -150,10 +150,6 @@ class DiscogsHandler():
                                         self.count += 1
                                         print('%8d -- Role \'%s\' invalid: https://www.discogs.com/release/%s' % (self.count, role, str(self.release)))
                                         continue
-        elif self.indescription:
-            if self.indescriptions:
-                if 'Styrene' in self.contentbuffer:
-                    pass
         elif self.inartistid:
             if self.config['check_artist']:
                 if self.contentbuffer == '0':
@@ -202,10 +198,6 @@ class DiscogsHandler():
         # now reset some values
         self.contentbuffer = ''
         self.inartistid = False
-        if name == 'descriptions':
-            self.indescriptions = True
-        elif not name == 'description':
-            self.indescriptions = False
 
         if name == 'artist':
             self.inartist = True
@@ -255,8 +247,6 @@ class DiscogsHandler():
             self.intracklist = True
         elif name == 'position':
             self.inposition = True
-        elif name == 'description':
-            self.indescription = True
         elif name == 'identifier':
             isdeposito = False
             attritems = dict(attrs.items())
@@ -712,6 +702,8 @@ def main(cfg, datadump, release_nr):
                         elif child.tag == 'formats':
                             for release_format in child:
                                 current_format = None
+
+                                # first check the attributes
                                 for (key, value) in release_format.items():
                                     if key == 'name':
                                         if value == 'CD':
@@ -745,6 +737,13 @@ def main(cfg, datadump, release_nr):
                                                 if current_format != 'Vinyl':
                                                     print_error(f'DMM ({current_format}, in Format)', release_id)
                                                     counter += 1
+
+                                # then process any children
+                                for ch in release_format:
+                                    if ch.tag == 'descriptions':
+                                        for description in ch:
+                                            if 'Styrene' in description.text:
+                                                pass
 
                         elif child.tag == 'genres':
                             for genre in child:

--- a/cleanup.config
+++ b/cleanup.config
@@ -5,6 +5,7 @@ label_code = yes
 label_name = yes
 mastering_sid = yes
 mould_sid = yes
+mould_sid_strict = no
 spars = yes
 isrc = yes
 asin = yes

--- a/cleanup.config
+++ b/cleanup.config
@@ -1,4 +1,5 @@
 [cleanup]
+artist = no
 deposito = yes
 rights_society = yes
 label_code = yes

--- a/cleanup.config
+++ b/cleanup.config
@@ -16,7 +16,7 @@ html = yes
 debug = no
 pkd = yes
 reportall = yes
-credits = yes
+credits = no
 tracklisting = yes
 
 ## location of file where to get the credit roles

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -113,7 +113,8 @@ isrc_ftf = set(['international standard recording code',
                 'icrs', 'international recording standard code', "isr code"])
 
 # a few rights societies from https://www.discogs.com/help/submission-guidelines-release-country.html
-rights_societies = set(["BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
+# as well as the place holder value "none"
+rights_societies = set(["NONE", "BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
                         "ΑΕΠΙ", "AGADU", "AKKA/LAA", "AKM", "ALBAUTOR",
                         "AMCOS", "APA", "APDASPAC", "APDAYC", "APRA",
                         "ARTISJUS", "ASCAP", "AUSTROMECHANA", "BMI", "BUMA",
@@ -224,7 +225,7 @@ rights_societies_wrong = set(['BOEM', 'BEIM', 'BIME', 'BIEN', 'BIE;', 'BIEIM',
                               'SGEA', 'SGSE', 'MPCS', 'MCPA', 'ACAP', 'ACSAP',
                               'ACSCAP', 'ACASP', 'ASAP', 'ASCA[', 'ASCAF',
                               'ASCA', 'ASCAP_', 'ASCAP,', 'ASCAPE', 'ASCSAP',
-                              'ASCVAP', 'ASCASP', 'ASXP', 'ASRTISJUS'])
+                              'ASCVAP', 'ASCASP', 'ASACP', 'ASXP', 'ASRTISJUS'])
 
 # a set of rights society names with characters from the wrong character set
 rights_societies_wrong_char = set(['ΒΙΕΜ', 'BΙEM', 'BΙΕΜ', 'BIEΜ', 'AEΠΙ',

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -484,8 +484,21 @@ nobarcode = set(['no barcode', 'without', 'without ean', 'without barcode',
 #
 # Format: (plant id, year production started, label name)
 #
-plants_compact_disc = [('7207', 1987, 'Dureco'), ('300888', 1987, 'Microservice'),
-                       ('56025', 1984, 'MPO'), ('93218', 1984, 'Nimbus'),
-                       ('147881', 1985, 'Mayking'), ('266256', 1989, 'EMI Uden'),
-                       ('291934', 1996, 'WEA Mfg Olyphant'), ('271323', 1986, 'Opti.Me.S')]
+plants_compact_disc = [(7207, 1987, 'Dureco'), (300888, 1987, 'Microservice'),
+                       (56025, 1984, 'MPO'), (93218, 1984, 'Nimbus'),
+                       (147881, 1985, 'Mayking'), (266256, 1989, 'EMI Uden'),
+                       (291934, 1996, 'WEA Mfg Olyphant'), (271323, 1986, 'Opti.Me.S')]
 
+# https://www.discogs.com/label/358102-PDO-USA
+# https://www.discogs.com/label/360848-PMDC-USA
+# https://www.discogs.com/label/266782-UML
+# https://www.discogs.com/label/381697-EDC-USA
+# https://www.discogs.com/label/358025-PDO-Germany
+# https://www.discogs.com/label/342158-PMDC-Germany
+# https://www.discogs.com/label/331548-Universal-M-L-Germany
+# https://www.discogs.com/label/384133-EDC-Germany
+
+plants = [(358102, 1986, 'PDO, USA'), (360848, 1992, 'PMDC, USA'), (266782, 1999, 'UML'),
+          (381697, 2005, 'EDC, USA'), (358025, 1986, 'PDO, Germany'),
+          (342158, 1993, 'PMDC, Germany'), (331548, 1999, 'Universal, M & L, Germany'),
+          (384133, 2005, 'EDC, Germany'), (265455, 1992, 'PMDC, France')]

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -484,7 +484,8 @@ nobarcode = set(['no barcode', 'without', 'without ean', 'without barcode',
 #
 # Format: (plant id, year production started, label name)
 #
-plants = [('7207', 1987, 'Dureco'), ('300888', 1987, 'Microservice'), ('56025', 1984, 'MPO'),
-          ('93218', 1984, 'Nimbus'), ('147881', 1985, 'Mayking'), ('266256', 1989, 'EMI Uden'),
-          ('291934', 1996, 'WEA Mfg Olyphant'), ('271323', 1986, 'Opti.Me.S')]
+plants_compact_disc = [('7207', 1987, 'Dureco'), ('300888', 1987, 'Microservice'),
+                       ('56025', 1984, 'MPO'), ('93218', 1984, 'Nimbus'),
+                       ('147881', 1985, 'Mayking'), ('266256', 1989, 'EMI Uden'),
+                       ('291934', 1996, 'WEA Mfg Olyphant'), ('271323', 1986, 'Opti.Me.S')]
 

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -113,8 +113,7 @@ isrc_ftf = set(['international standard recording code',
                 'icrs', 'international recording standard code', "isr code"])
 
 # a few rights societies from https://www.discogs.com/help/submission-guidelines-release-country.html
-# as well as the place holder value "none"
-rights_societies = set(["NONE", "BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
+rights_societies = set(["BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
                         "ΑΕΠΙ", "AGADU", "AKKA/LAA", "AKM", "ALBAUTOR",
                         "AMCOS", "APA", "APDASPAC", "APDAYC", "APRA",
                         "ARTISJUS", "ASCAP", "AUSTROMECHANA", "BMI", "BUMA",

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -113,7 +113,7 @@ isrc_ftf = set(['international standard recording code',
                 'icrs', 'international recording standard code', "isr code"])
 
 # a few rights societies from https://www.discogs.com/help/submission-guidelines-release-country.html
-rights_societies = set(["BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
+rights_societies = set(["BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
                         "ΑΕΠΙ", "AGADU", "AKKA/LAA", "AKM", "ALBAUTOR",
                         "AMCOS", "APA", "APDASPAC", "APDAYC", "APRA",
                         "ARTISJUS", "ASCAP", "AUSTROMECHANA", "BMI", "BUMA",
@@ -185,13 +185,18 @@ rights_societies_ftf = set(['(right societies)', '(rights society',
                             'original rights', 'rights info'])
 
 # several possible misspellings of rights societies
-# Not all of these are wrong all the time: STEMPRA has been used
-# on actual releases:
+# Not all of these are necessarily Discogs user errors.
+#
+# As an example STEMPRA has been used on actual releases:
+#
 # https://www.discogs.com/release/8578592
 # https://www.discogs.com/release/629916
+#
 # STEMA:
+#
 # https://www.discogs.com/release/1511006
 # https://www.discogs.com/release/529700
+#
 # There are a few wrong values, but currently they are also triggered
 # by correct values, so they are ignored for now.
 #rights_societies_wrong = set(['BIE', 'TEMRA'])

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -390,7 +390,7 @@ sid_ignore = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<n
                   'no ifpi', 'no ifpi code', 'unstated', '[blank]', 'unable to read',
                   'can\'t find', 'can\'t find it', 'no code discernible', 'vacant',
                   '[none observed]', 'indistinct', 'information missing', 'no information',
-                  '(too faint to see)', 'without sid',
+                  '(too faint to see)', 'without sid', 'present, but digits cannot be identified',
                   'There is something on the innermost edge but it is unreadable'])
 
 # a list of creative commons identifiers

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -131,7 +131,8 @@ rights_societies = set(["BEL BIEM", "BEL/BIEM", "BIEM", "ACAM", "ACDAM", "ACUM",
                         "SESAC", "SGA", "SGAE", "SIAE", "SIMIM", "SOCAN",
                         "SODRAC", "SOKOJ", "SOZA", "SPA", "STEF", "STEMRA",
                         "STIM", "SUISA", "TEOSTO", "TONO", "UACRR", "UBC",
-                        "UCMR-ADA", "ZAIKS", "ZPAV", "SACEM", "SACD", "SDRM", "SGDL"])
+                        "UCMR-ADA", "ZAIKS", "ZPAV", "SACEM", "SACD", "SDRM", "SGDL",
+                        "SACEM SDRM SACD SGDL"])
 
 rights_societies_ftf = set(['(right societies)', '(rights society',
                             '(rights society)', 'collection society',

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -199,7 +199,7 @@ rights_societies_ftf = set(['(right societies)', '(rights society',
 #
 # There are a few wrong values, but currently they are also triggered
 # by correct values, so they are ignored for now.
-#rights_societies_wrong = set(['BIE', 'TEMRA'])
+#rights_societies_wrong = set(['BIE', 'TEMRA', 'STEMR'])
 rights_societies_wrong = set(['BOEM', 'BEIM', 'BIME', 'BIEN', 'BIE;', 'BIEIM',
                               'BIEAM', 'BIEEM', 'BIELM', 'BIEL', 'BIEMA',
                               'BIETM', 'BIRM', 'BIER', 'BIERM', 'BIE,', 'BIEW',
@@ -207,13 +207,13 @@ rights_societies_wrong = set(['BOEM', 'BEIM', 'BIME', 'BIEN', 'BIE;', 'BIEIM',
                               'BUMDA', 'BUMRA', 'ETEMRA', 'SEMRA', 'SEMTRA',
                               'STAMRA', 'STEAMRA', 'STREMA', 'STREMRA',
                               'STERMA', 'STERMRA', 'STEMA', 'STERA', 'STETMRA',
-                              'STEMPRA', 'STEMCA', 'STEMPA', 'STEMBRA',
-                              'STEMERA', 'STEMTA', 'STEMRS', 'STEMMA',
-                              'STEMRE', 'STEMRO', 'STEMPIA', 'STEMTRA',
+                              'STERNA', 'STEMPRA', 'STEMCA', 'STEMPA', 'STEMBRA',
+                              'STEMERA', 'STEMTA', 'STEMRS', 'STEMMA', 'STEMRAA',
+                              'STEMRE', 'STEMRO', 'STEMPIA', 'STEMTRA', 'STEMEA',
                               'STENRA', 'SREMRA', 'JAIRAC', 'JAJSRAC',
                               'JAMRAC', 'JASPAC', 'JASDAC', 'JASARC', 'JASMAC',
                               'JASNAC', 'JASRACK', 'JASREC', 'JASTAC',
-                              'JASTRAC', 'JASRAK', 'JASRC', 'JASRAQ',
+                              'JASTRAC', 'JASRAK', 'JASRC', 'JASRAQ', 'ASRAC',
                               'JASARAC', 'JASCRAC', 'JARAC', 'JSARAC', 'JSRAC',
                               'JASHAC', 'RJASRAC', 'YASRAC', 'GMA', 'GENA',
                               'GAMA', 'GE;A', 'GAME', 'GEMRA', 'GGEMA',
@@ -221,7 +221,10 @@ rights_societies_wrong = set(['BOEM', 'BEIM', 'BIME', 'BIEN', 'BIE;', 'BIEIM',
                               'GEME', 'GEMM', 'GEMS', 'GMEA', 'SSABAM', 'SBAM',
                               'SABBAM', 'SABEM', 'SABAN', 'SABM', 'SABIAM',
                               'SABMA', 'SABAAM', 'SAAM', 'SABNAM', 'SEBAM',
-                              'SGEA', 'SGSE', 'MPCS', 'MCPA'])
+                              'SGEA', 'SGSE', 'MPCS', 'MCPA', 'ACAP', 'ACSAP',
+                              'ACSCAP', 'ACASP', 'ASAP', 'ASCA[', 'ASCAF',
+                              'ASCA', 'ASCAP_', 'ASCAP,', 'ASCAPE', 'ASCSAP',
+                              'ASCVAP', 'ASCASP', 'ASXP', 'ASRTISJUS'])
 
 # a set of rights society names with characters from the wrong character set
 rights_societies_wrong_char = set(['ΒΙΕΜ', 'BΙEM', 'BΙΕΜ', 'BIEΜ', 'AEΠΙ',

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 #
-# Copyright 2017-2023 - Armijn Hemel
+# Copyright 2017-2024 - Armijn Hemel
 
 import re
 
@@ -113,6 +113,7 @@ isrc_ftf = set(['international standard recording code',
                 'icrs', 'international recording standard code', "isr code"])
 
 # a few rights societies from https://www.discogs.com/help/submission-guidelines-release-country.html
+# These are all uppercased.
 rights_societies = set(["BEL BIEM", "BEL/BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
                         "ΑΕΠΙ", "AGADU", "AKKA/LAA", "AKM", "ALBAUTOR",
                         "AMCOS", "APA", "APDASPAC", "APDAYC", "APRA",
@@ -184,7 +185,7 @@ rights_societies_ftf = set(['(right societies)', '(rights society',
                             'rights associations', 'rights association',
                             'original rights', 'rights info'])
 
-# several possible misspellings of rights societies
+# several possible misspellings of rights societies, all uppercased
 # Not all of these are necessarily Discogs user errors.
 #
 # As an example STEMPRA has been used on actual releases:
@@ -336,6 +337,10 @@ mouldsids = set(['mould sid code', 'mould sid', 'mold sid', 'mold sid code',
                  'mould s.i.d.', 'mould s.i.d. code', 'moulds.i.d. code',
                  's.i.d. mould code', 's.i.d. moulding code',
                  'modul sid code (both discs)'])
+
+possible_mastering_sid = set(['sid code matrix', 'sid code - matrix', 'sid code (matrix)',
+                              'sid-code, matrix', 'sid-code matrix', 'sid code (matrix ring)',
+                              'sid code, matrix ring', 'sid code: matrix ring'])
 
 # a list of creative commons identifiers
 creativecommons = ['CC-BY-NC-ND', 'CC-BY-ND', 'CC-BY-SA', 'ShareAlike']

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -16,11 +16,11 @@ depositores = []
 # First the most common ones
 depositores.append(re.compile(r'depósito legal'))
 depositores.append(re.compile(r'deposito legal'))
-depositores.append(re.compile(r'de?s?p*ós*i?r?tl?o?i?\s*l+e?g?al?\.?'))
+depositores.append(re.compile(r'de?s?p*ós*t?i?r?t?l?o?i?\s*l+e?g?al?\.?'))
 depositores.append(re.compile(r'des?p?os+ito?\s+legt?al?\.?'))
 depositores.append(re.compile(r'legal? des?posit'))
 depositores.append(re.compile(r'dep\.\s*legal'))
-depositores.append(re.compile(r'dip. legal'))
+depositores.append(re.compile(r'dip.\s* legal'))
 depositores.append(re.compile(r'dip. leg.'))
 depositores.append(re.compile(r'dipòsit legal'))
 depositores.append(re.compile(r'dipósit legal'))
@@ -69,6 +69,7 @@ depositores.append(re.compile(r'legak des?posit'))
 depositores.append(re.compile(r'legai des?posit'))
 depositores.append(re.compile(r'legal depos?t'))
 depositores.append(re.compile(r'legal dep\.'))
+depositores.append(re.compile(r'legal submis+ion'))
 
 # basque DL:
 # http://www.euskadi.eus/deposito-legal/web01-a2libzer/es/impresion.html

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -342,6 +342,57 @@ possible_mastering_sid = set(['sid code matrix', 'sid code - matrix', 'sid code 
                               'sid-code, matrix', 'sid-code matrix', 'sid code (matrix ring)',
                               'sid code, matrix ring', 'sid code: matrix ring'])
 
+# some values that are not the actual data, but are metadata describing
+# something about the SID codes (readable, missing, and so on) or about
+# actions that need to be taken.
+sid_ignore = set(['none', 'none?', 'none (?)', '(none)', '-none-', '[none]', '<none>', '\'none\'',
+                  'none.', 'non', 'nond', 'none found', 'none or hidden', 'none given', 'not',
+                  'not present', '(not present)', '[not present]', '<not present>',
+                  'not present or not entered', '[not yet identified]', 'nothing',
+                  'none / [missing]', 'missing', '(missing)', '?missing?', '"missing"',
+                  '[missing]', '(missing info)', '[missing data]', '[missing or not entered]',
+                  'missing entry', 'not available', '(not available)', '[not available]',
+                  'not found', '(not found)', '[not found]', '(not found on cd)',
+                  'missing / not found', '[indecipherable]', '(indistinguishable)', 'not known',
+                  'unknown', '(unknown)', '[unknown]', 'unk', 'not on disc', 'not visible',
+                  '(not visible)', '(not visble)', '[not visible]', 'not visible/present',
+                  'none or not visible', 'not visible on both cds', 'not visible (black cd)',
+                  'not visable', 'none visible', '[none visible]', 'non visible',
+                  '[no code visible]', '[none recorded]', '[none or missing]', 'none seen',
+                  '[none seen]', '[not seen]', 'not registered', 'none detected', 'none entered',
+                  'not entered', '[not entered]', '(not entered', '(not entered)',
+                  '[nothing entered]', 'not enterd', 'none or not entered', '(none or not entered)',
+                  '[none or not entered]', 'not entered / none', 'not entered or none',
+                  '(not entered or none)', '[not entered/none]', '... not entered ...',
+                  '[to be entered]', 'not entered or not present', 'need to be entered',
+                  'to be confirmed', '[?]', '[? ?]', '?', '??', '???', '????', '???????',
+                  '(???)', 'no', 'not recorded', '[not recorded]', 'not supplied', '(not supplied)',
+                  '[not supplied]', 'none supplied', 'unreadable', '[unreadable]', '(unreadable)',
+                  'unreadable/too small', 'none or unreadable', 'nil', 'not given',
+                  '(not given)', '[not given]', 'not inserted', '(not inserted)', '[not inserted]',
+                  'not added', '(not added)', '[not added]', '[not added yet]',
+                  '(to be added by another user)', 'none cited', 'not provided', '(not provided)',
+                  'not stated', '[not stated]', 'not submitted', '[not submitted]',
+                  '[not submittted]', '(not apparent)', '[not apparent]', '<not apparent>',
+                  'none apparent', 'apparently none', 'not legible', '[not legible]', 'illegible',
+                  '[illegible]', 'no sid', 'no sid code', 'no sid codes', 'no mastering sid code',
+                  'not detectable', 'none or not detectable', '[not discernable]', 'not readable',
+                  '(not readable)', '[not readable]', '[none/not readable]',
+                  '[none / not readable]', 'not readable (to small)', 'not clearly readable',
+                  'can not read', '[not reported]', 'no code', '[no code]', '(empty)', '[empty]',
+                  'cannot locate', 'to be completed', 'obscured', 'invisible',
+                  '[not yet identified]', 'unidentified', 'not specified', 'no specified',
+                  'not included', 'not noted', '[not provided by user]', 'not shown',
+                  'still missing', 'none stated', 'absent', '[absent]', 'n/a', 'undetermined',
+                  '(doesnt have one)', 'non-existend', 'no mould', 'no mould sid',
+                  'no mould sid code', '(no mould sid code)', '[no mould sid code]',
+                  '"no mould sid code"', 'no mould sid-code', 'no mould code', '(no mould code)',
+                  'no ifpi', 'no ifpi code', 'unstated', '[blank]', 'unable to read',
+                  'can\'t find', 'can\'t find it', 'no code discernible', 'vacant',
+                  '[none observed]', 'indistinct', 'information missing', 'no information',
+                  '(too faint to see)', 'without sid',
+                  'There is something on the innermost edge but it is unreadable'])
+
 # a list of creative commons identifiers
 creativecommons = ['CC-BY-NC-ND', 'CC-BY-ND', 'CC-BY-SA', 'ShareAlike']
 

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -439,3 +439,52 @@ nobarcode = set(['no barcode', 'without', 'without ean', 'without barcode',
                  'no barcord', 'no bracode', 'no borcode', 'no contiene cod de barras.',
                  'w/o code',
                 ])
+
+# pressing plants
+#
+# Dureco:
+# -------
+# https://www.discogs.com/label/7207-Dureco
+# https://dureco.wordpress.com/2014/12/09/opening-cd-fabriek-weesp/
+# https://www.anderetijden.nl/aflevering/141/De-komst-van-het-schijfje (starting 22:25)
+# https://books.google.nl/books?id=yyQEAAAAMBAJ&pg=RA1-PA37&lpg=RA1-PA37&dq=dureco+CDs+1987&source=bl&ots=cwc3WPM3Nw&sig=t0man_qWguylE9HEyqO39axo8kM&hl=nl&sa=X&ved=0ahUKEwjdme-xxcTZAhXN26QKHURgCJc4ChDoAQg4MAE#v=onepage&q&f=false
+# https://www.youtube.com/watch?v=laDLvlj8tIQ
+# https://krantenbankzeeland.nl/issue/pzc/1987-09-19/edition/0/page/21
+#
+# Since Dureco was also a distributor there are
+# sometimes false positives
+#
+# Microservice:
+# -------------
+# https://www.discogs.com/label/300888-Microservice-Microfilmagens-e-Reprodu%C3%A7%C3%B5es-T%C3%A9cnicas-Ltda
+#
+# MPO:
+# ----
+# https://www.discogs.com/label/56025-MPO
+#
+# Nimbus:
+# ------
+# https://www.discogs.com/label/93218-Nimbus
+#
+# Mayking:
+# -------
+# https://www.discogs.com/label/147881-Mayking
+#
+# EMI Uden:
+# --------
+# https://www.discogs.com/label/266256-EMI-Uden
+#
+# WEA Mfg Olyphant:
+# -----------------
+# https://www.discogs.com/label/291934-WEA-Mfg-Olyphant
+#
+# Opti.Me.S:
+# ----------
+# https://www.discogs.com/label/271323-OptiMeS
+#
+# Format: (plant id, year production started, label name)
+#
+plants = [('7207', 1987, 'Dureco'), ('300888', 1987, 'Microservice'), ('56025', 1984, 'MPO'),
+          ('93218', 1984, 'Nimbus'), ('147881', 1985, 'Mayking'), ('266256', 1989, 'EMI Uden'),
+          ('291934', 1996, 'WEA Mfg Olyphant'), ('271323', 1986, 'Opti.Me.S')]
+

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -113,7 +113,7 @@ isrc_ftf = set(['international standard recording code',
                 'icrs', 'international recording standard code', "isr code"])
 
 # a few rights societies from https://www.discogs.com/help/submission-guidelines-release-country.html
-rights_societies = set(["BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
+rights_societies = set(["BEL BIEM", "BEL/BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "AEPI",
                         "ΑΕΠΙ", "AGADU", "AKKA/LAA", "AKM", "ALBAUTOR",
                         "AMCOS", "APA", "APDASPAC", "APDAYC", "APRA",
                         "ARTISJUS", "ASCAP", "AUSTROMECHANA", "BMI", "BUMA",
@@ -122,15 +122,15 @@ rights_societies = set(["BEL BIEM", "BIEM", "ACAM", "ACDAM", "ACUM", "ADDAF", "A
                         "GESAP", "GRAMO", "GVL", "HDS", "HFA", "IMRO", "IPRS",
                         "JASRAC", "KCI", "KODA", "KOMCA", "LATGA-A", "MACP",
                         "MECOLICO", "MCPS", "MCSC", "MCSK", "MESAM",
-                        "MUSICAUTOR", "MUST", "NCB", "n©b", "N©B", "N(C)B",
+                        "MUSICAUTOR", "MUST", "NCB", "N©B", "N(C)B",
                         "OSA", "PAMRA", "PPL", "PROCAN", "PRS", "RAO", "SABAM",
-                        "SACEM", "SACEM Luxembourg", "SACM", "SACVEN",
+                        "SACEM", "SACEM LUXEMBOURG", "SACM", "SACVEN",
                         "SADAIC", "SAKOJ", "SAMI", "SAMRO", "SAYCO", "SAZAS",
                         "SBACEM", "SCPP", "SCD", "SDRM", "SEDRIM", "SENA",
                         "SESAC", "SGA", "SGAE", "SIAE", "SIMIM", "SOCAN",
                         "SODRAC", "SOKOJ", "SOZA", "SPA", "STEF", "STEMRA",
                         "STIM", "SUISA", "TEOSTO", "TONO", "UACRR", "UBC",
-                        "UCMR-ADA", "ZAIKS", "ZPAV"])
+                        "UCMR-ADA", "ZAIKS", "ZPAV", "SACEM", "SACD", "SDRM", "SGDL"])
 
 rights_societies_ftf = set(['(right societies)', '(rights society',
                             '(rights society)', 'collection society',

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -502,3 +502,6 @@ plants = [(358102, 1986, 'PDO, USA'), (360848, 1992, 'PMDC, USA'), (266782, 1999
           (381697, 2005, 'EDC, USA'), (358025, 1986, 'PDO, Germany'),
           (342158, 1993, 'PMDC, Germany'), (331548, 1999, 'Universal, M & L, Germany'),
           (384133, 2005, 'EDC, Germany'), (265455, 1992, 'PMDC, France')]
+
+pmdc_misspellings = ['MADE IN USA BY PDMC', 'MADE IN GERMANY BY PDMC',
+                     'MADE IN FRANCE BY PDMC', 'PDMC FRANCE']

--- a/discogssmells.py
+++ b/discogssmells.py
@@ -69,6 +69,7 @@ depositores.append(re.compile(r'legak des?posit'))
 depositores.append(re.compile(r'legai des?posit'))
 depositores.append(re.compile(r'legal depos?t'))
 depositores.append(re.compile(r'legal dep\.'))
+depositores.append(re.compile(r'legal nr\.'))
 depositores.append(re.compile(r'legal submis+ion'))
 
 # basque DL:
@@ -271,7 +272,7 @@ masteringsids = set(['mastering sid code', 'master sid code', 'master sid',
                      'mastering sid сode', 'masterin sid code',
                      'cd centre etching - mastering sid code',
                      'sid mastering code cd2', 'master s.i.d.',
-                     'master s.i.d. code'])
+                     'master s.i.d. code', 'dvd - mastering sid code'])
 
 mouldsids = set(['mould sid code', 'mould sid', 'mold sid', 'mold sid code',
                  'modul sid code', 'moould sid code', 'moudl sid code',
@@ -338,7 +339,7 @@ mouldsids = set(['mould sid code', 'mould sid', 'mold sid', 'mold sid code',
                  'mould sid code disc 2', 'mould sid code dvd1',
                  'mould s.i.d.', 'mould s.i.d. code', 'moulds.i.d. code',
                  's.i.d. mould code', 's.i.d. moulding code',
-                 'modul sid code (both discs)'])
+                 'modul sid code (both discs)', 'inner mould sid code'])
 
 possible_mastering_sid = set(['sid code matrix', 'sid code - matrix', 'sid code (matrix)',
                               'sid-code, matrix', 'sid-code matrix', 'sid code (matrix ring)',


### PR DESCRIPTION
rewrite the old parser to use ElementTree instead of a SAX parser. This PR also makes checks more maintainable, fixes a few known erorrs (mostly related to spanish deposito legal values) and gives more information about the errors that were found, so it is (hopefully) easier to filter outputs and correct errors in a more focused way.